### PR TITLE
Add GitHub CI workflow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to npm
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          registry-url: 'https://registry.npmjs.org'
+          always-auth: true
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the project
+        run: npm run build
+
+      # Semantic versioning is applied manually; CI does not commit any version changes.
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag latest 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,11 @@
+# Manual Test for CI Publish Workflow
+
+1. Push a commit to the main branch (or merge the PR) to trigger the workflow.
+2. Check the Actions tab in your GitHub repository to see that the "Publish to npm" workflow runs successfully.
+3. Verify that the package is published to npm with the expected version (0.0.0-development) without any new commits from the workflow.
+
+## Important Notes
+
+- The CI workflow will not make any commits or version bumps
+- Version updates should be handled manually outside of CI
+- Make sure you have set up the `NPM_TOKEN` secret in your GitHub repository settings 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cursor-worktree",
-	"version": "1.0.0",
+	"version": "0.0.0-development",
 	"description": "A CLI tool for managing Git worktrees with a focus on opening them in the Cursor editor.",
 	"author": "Your Name",
 	"license": "MIT",


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build and publish the package to npm. The workflow runs on pushes to main and uses semantic versioning without making commits during CI runs.