### PR TITLE
feat: add --force flag to remove command

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,3 +18,22 @@
    ```
 2. Verify that a new sibling directory named `<currentDirectoryName>editor` is created.
 3. Confirm that the worktree is added to the Git repository and that the Cursor editor opens the new directory. 
+
+## Remove Worktree Force Flag Test
+
+1. Create a test worktree:
+   ```bash
+   cursor-worktree new test-branch
+   ```
+2. Make some changes in the worktree that would prevent normal removal
+3. Try removing the worktree without the force flag:
+   ```bash
+   cursor-worktree remove test-branch
+   ```
+   This should fail if there are uncommitted changes
+4. Try removing the worktree with the force flag:
+   ```bash
+   cursor-worktree remove --force test-branch
+   ```
+   This should succeed and remove the worktree regardless of its state
+5. Verify that the worktree directory is removed and the Git worktree reference is cleaned up 

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -3,7 +3,10 @@ import chalk from "chalk";
 import { stat, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 
-export async function removeWorktreeHandler(pathOrBranch: string = "") {
+export async function removeWorktreeHandler(
+    pathOrBranch: string = "",
+    options: { force?: boolean }
+) {
     try {
         await execa("git", ["rev-parse", "--is-inside-work-tree"]);
 
@@ -47,8 +50,8 @@ export async function removeWorktreeHandler(pathOrBranch: string = "") {
 
         console.log(chalk.blue(`Removing worktree: ${targetPath}`));
 
-        // Remove from Git's perspective
-        await execa("git", ["worktree", "remove", targetPath]);
+        // Pass the "--force" flag to Git if specified
+        await execa("git", ["worktree", "remove", ...(options.force ? ["--force"] : []), targetPath]);
 
         // Optionally also remove the physical directory if it still exists
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ program
 program
     .command("remove")
     .argument("[pathOrBranch]", "Path of the worktree or branch to remove.")
+    .option("-f, --force", "Force removal of worktree and deletion of the folder", false)
     .description("Remove a specified worktree. Cleans up the .git/worktrees references.")
     .action(removeWorktreeHandler);
 


### PR DESCRIPTION
This PR adds a --force flag to the remove command, allowing users to force remove worktrees even when they have uncommitted changes.