### PR TITLE
Change CLI command name to 'cwt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pnpm install -g .
 ### Create a new worktree
 
 ```bash
-cursor-worktree new <branchName> [options]
+cwt new <branchName> [options]
 ```
 
 Options:
@@ -22,27 +22,27 @@ Options:
 
 Example:
 ```bash
-cursor-worktree new feature/login
-cursor-worktree new feature/chat --checkout
-cursor-worktree new feature/auth -p ./auth-worktree
+cwt new feature/login
+cwt new feature/chat --checkout
+cwt new feature/auth -p ./auth-worktree
 ```
 
 ### List worktrees
 
 ```bash
-cursor-worktree list
+cwt list
 ```
 
 ### Remove a worktree
 
 ```bash
-cursor-worktree remove <pathOrBranch>
+cwt remove <pathOrBranch>
 ```
 
 You can remove a worktree by either its path or branch name:
 ```bash
-cursor-worktree remove ./feature/login-worktree
-cursor-worktree remove feature/chat
+cwt remove ./feature/login-worktree
+cwt remove feature/chat
 ```
 
 ## Requirements

--- a/TESTING.md
+++ b/TESTING.md
@@ -18,3 +18,27 @@
    ```
 2. Verify that a new sibling directory named `<currentDirectoryName>editor` is created.
 3. Confirm that the worktree is added to the Git repository and that the Cursor editor opens the new directory. 
+
+## Manual Test for CLI Command Name Change
+
+1. Install the package globally:
+   ```bash
+   pnpm install -g .
+   ```
+2. Run the command help to verify the new command:
+   ```bash
+   cwt --help
+   ```
+3. Optionally, test additional commands:
+   - Create a new worktree:
+     ```bash
+     cwt new feature/test
+     ```
+   - List worktrees:
+     ```bash
+     cwt list
+     ```
+   - Remove a worktree:
+     ```bash
+     cwt remove feature/test
+     ``` 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"license": "MIT",
 	"type": "module",
 	"bin": {
-		"cursor-worktree": "dist/index.js"
+		"cwt": "dist/index.js"
 	},
 	"scripts": {
 		"build": "tsc",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { removeWorktreeHandler } from "./commands/remove.js";
 const program = new Command();
 
 program
-    .name("cursor-worktree")
+    .name("cwt")
     .description("Manage git worktrees and open them in the Cursor editor.")
     .version("1.0.0");
 


### PR DESCRIPTION
This PR changes the main CLI command name from 'cursor-worktree' to 'cwt' for better usability. Changes include:\n\n- Updated bin field in package.json\n- Updated program name in src/index.ts\n- Updated all command examples in README.md\n- Added manual testing instructions in TESTING.md