### PR TITLE
feat: Add purge command to remove non-main worktrees

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -92,3 +92,26 @@
 - The CI workflow will not make any commits or version bumps
 - Version updates should be handled manually outside of CI
 - Make sure you have set up the `NPM_TOKEN` secret in your GitHub repository settings 
+
+## Manual Test for Purge Command
+
+1. **Setup Test Worktrees:**
+   - Create two new worktrees on branches other than main:
+     ```bash
+     wt new test-branch1
+     wt new test-branch2
+     ```
+2. **Execute Purge Command:**
+   - Run the purge command:
+     ```bash
+     wt purge
+     ```
+3. **Confirmation:**
+   - For each listed worktree, verify that the branch and path are displayed.
+   - When prompted, enter `y` to remove a worktree or any other key to skip.
+4. **Verification:**
+   - After purging, run:
+     ```bash
+     git worktree list
+     ```
+     Ensure that only the main branch worktree remains (or those you opted not to remove).

--- a/src/commands/purge.ts
+++ b/src/commands/purge.ts
@@ -1,0 +1,87 @@
+import { execa } from "execa";
+import chalk from "chalk";
+import { stat, rm } from "node:fs/promises";
+import readline from "node:readline";
+
+// Utility function for interactive confirmation
+function askQuestion(query: string): Promise<string> {
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+    return new Promise((resolve) => rl.question(query, (ans) => {
+        rl.close();
+        resolve(ans);
+    }));
+}
+
+export async function purgeWorktreesHandler() {
+    try {
+        // Ensure we're in a Git repository
+        await execa("git", ["rev-parse", "--is-inside-work-tree"]);
+
+        // Retrieve worktree list in porcelain format
+        const { stdout } = await execa("git", ["worktree", "list", "--porcelain"]);
+        const lines = stdout.split("\n");
+        const worktrees: { path: string; branch: string }[] = [];
+        let currentPath = "";
+
+        // Parse worktree information from porcelain output
+        for (const line of lines) {
+            if (line.startsWith("worktree ")) {
+                currentPath = line.replace("worktree ", "").trim();
+            } else if (line.startsWith("branch ")) {
+                const fullBranch = line.replace("branch ", "").trim();
+                const branch = fullBranch.replace("refs/heads/", "");
+                worktrees.push({ path: currentPath, branch });
+            }
+        }
+
+        if (worktrees.length === 0) {
+            console.log(chalk.yellow("No worktrees found."));
+            return;
+        }
+
+        // Filter out the main branch worktree
+        const purgeWorktrees = worktrees.filter((wt) => wt.branch !== "main");
+
+        if (purgeWorktrees.length === 0) {
+            console.log(chalk.green("No worktrees to purge (only main remains)."));
+            return;
+        }
+
+        console.log(chalk.blue(`Found ${purgeWorktrees.length} worktree(s) to potentially purge:`));
+
+        // Loop through each worktree and ask for confirmation before removal
+        for (const wt of purgeWorktrees) {
+            console.log(chalk.blue(`Worktree: Branch "${wt.branch}" at path "${wt.path}"`));
+            const answer = await askQuestion(`Do you want to remove this worktree? (y/N): `);
+            if (answer.toLowerCase() === "y") {
+                console.log(chalk.blue(`Removing worktree for branch "${wt.branch}"...`));
+                // Remove worktree using Git
+                await execa("git", ["worktree", "remove", wt.path]);
+                console.log(chalk.green(`Removed worktree at ${wt.path}.`));
+
+                // Optionally remove the physical directory if it still exists
+                try {
+                    await stat(wt.path);
+                    await rm(wt.path, { recursive: true, force: true });
+                    console.log(chalk.green(`Deleted folder ${wt.path}.`));
+                } catch {
+                    // If the directory doesn't exist, continue silently.
+                }
+            } else {
+                console.log(chalk.yellow(`Skipping removal for worktree "${wt.branch}".`));
+            }
+        }
+
+        console.log(chalk.green("Purge command completed."));
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error(chalk.red("Failed to purge worktrees:"), error.message);
+        } else {
+            console.error(chalk.red("Failed to purge worktrees:"), error);
+        }
+        process.exit(1);
+    }
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { newWorktreeHandler } from "./commands/new.js";
 import { listWorktreesHandler } from "./commands/list.js";
 import { removeWorktreeHandler } from "./commands/remove.js";
 import { mergeWorktreeHandler } from "./commands/merge.js";
+import { purgeWorktreesHandler } from "./commands/purge.js";
 
 const program = new Command();
 
@@ -42,5 +43,10 @@ program
     .option("-f, --force", "Force removal of worktree after merge", false)
     .description("Commit changes in the target branch and merge them into the current branch, then remove the branch/worktree")
     .action(mergeWorktreeHandler);
+
+program
+    .command("purge")
+    .description("Safely remove all worktrees except for the main branch, with confirmation.")
+    .action(purgeWorktreesHandler);
 
 program.parse(process.argv); 


### PR DESCRIPTION
Adds a new purge command that lists all Git worktrees (except for the main branch), shows each worktree's information, asks for confirmation, and then removes selected worktrees safely.