### PR TITLE
feat: Handle slashes in branch names for directory generation in 'wt new'

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -17,11 +17,15 @@ export async function newWorktreeHandler(
         if (options.path) {
             folderName = options.path;
         } else {
+            // Derive the short name for the directory from the branch name
+            // This handles cases like 'feature/login' -> 'login'
+            const shortBranchName = branchName.split('/').filter(part => part.length > 0).pop() || branchName;
+
             const currentDir = process.cwd();
             const parentDir = dirname(currentDir);
             const currentDirName = basename(currentDir);
-            // Create a sibling directory: current directory name concatenated with branchName
-            folderName = join(parentDir, `${currentDirName}-${branchName}`);
+            // Create a sibling directory using the short branch name
+            folderName = join(parentDir, `${currentDirName}-${shortBranchName}`);
         }
         const resolvedPath = resolve(folderName);
 


### PR DESCRIPTION
## Description

Handles branch names containing slashes (e.g., 'feature/login') when generating the sibling directory name for a new worktree created with 'wt new'.

When a user runs 'wt new feature/login', the directory created will now be 'project-name-login' instead of attempting an invalid 'project-name-feature/login'. The full branch name 'feature/login' is still correctly used for the actual Git branch.

## Changes Made

- Modified 'src/commands/new.ts' to extract the last segment of the branch name for directory path generation when no explicit '--path' is given.
- Ensured the full, original branch name is always used when interacting with Git ('git worktree add').

## Testing

- Manually tested with 'wt new feature/test-slash' and verified correct directory ('project-test-slash') and branch ('feature/test-slash') creation.
