### PR TITLE
Fix: Prevent Main Repo Bare Config and Ensure Clean State

### DIFF
--- a/src/commands/merge.ts
+++ b/src/commands/merge.ts
@@ -2,6 +2,7 @@ import { execa } from "execa";
 import chalk from "chalk";
 import { stat, rm } from "node:fs/promises";
 import { resolve } from "node:path";
+import { isMainRepoBare } from "../utils/git.js";
 
 export async function mergeWorktreeHandler(
     branchName: string,
@@ -70,6 +71,14 @@ export async function mergeWorktreeHandler(
 
         // Step 3: Remove the worktree for the merged branch (similar to 'wt remove')
         console.log(chalk.blue(`Removing worktree for branch "${branchName}"...`));
+
+        if (await isMainRepoBare()) {
+            console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
+            console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
+            console.error(chalk.cyan("   git config core.bare false"));
+            process.exit(1);
+        }
+
         const removeArgs = ["worktree", "remove", ...(options.force ? ["--force"] : []), targetPath];
         await execa("git", removeArgs);
         console.log(chalk.green(`Removed worktree at ${targetPath}.`));

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -3,7 +3,7 @@ import chalk from "chalk";
 import { stat } from "node:fs/promises";
 import { resolve, join, dirname, basename } from "node:path";
 import { getDefaultEditor } from "../config.js";
-import { isWorktreeClean } from "../utils/git.js";
+import { isWorktreeClean, isMainRepoBare } from "../utils/git.js";
 
 export async function newWorktreeHandler(
     branchName: string = "main",
@@ -16,11 +16,10 @@ export async function newWorktreeHandler(
         console.log(chalk.blue("Checking if main worktree is clean..."));
         const isClean = await isWorktreeClean(".");
         if (!isClean) {
-            console.warn(chalk.yellow("⚠️ Warning: Your main worktree is not clean."));
-            console.warn(chalk.yellow("While 'wt new' might succeed, it's generally recommended to have a clean state."));
-            console.warn(chalk.cyan("Run 'git status' to review changes. Consider committing or stashing."));
-            // Decide whether to exit or just warn. Warning might be sufficient here.
-            // process.exit(1);
+            console.error(chalk.red("❌ Error: Your main worktree is not clean."));
+            console.error(chalk.yellow("Creating a new worktree requires a clean main worktree state."));
+            console.error(chalk.cyan("Please commit, stash, or discard your changes. Run 'git status' to see the changes."));
+            process.exit(1); // Exit if not clean
         } else {
             console.log(chalk.green("✅ Main worktree is clean."));
         }
@@ -78,6 +77,13 @@ export async function newWorktreeHandler(
             // Skip to opening editor
         } else {
             console.log(chalk.blue(`Creating new worktree for branch "${branchName}" at: ${resolvedPath}`));
+
+            if (await isMainRepoBare()) {
+                console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
+                console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
+                console.error(chalk.cyan("   git config core.bare false"));
+                process.exit(1);
+            }
 
             if (!branchExists) {
                 console.log(chalk.yellow(`Branch "${branchName}" doesn't exist. Creating new branch with worktree...`));

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -2,6 +2,7 @@ import { execa } from "execa";
 import chalk from "chalk";
 import { stat, rm } from "node:fs/promises";
 import { resolve } from "node:path";
+import { isMainRepoBare } from "../utils/git.js";
 
 export async function removeWorktreeHandler(
     pathOrBranch: string = "",
@@ -49,6 +50,14 @@ export async function removeWorktreeHandler(
         }
 
         console.log(chalk.blue(`Removing worktree: ${targetPath}`));
+
+        // >>> ADD SAFETY CHECK HERE <<<
+        if (await isMainRepoBare()) {
+            console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
+            console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
+            console.error(chalk.cyan("   git config core.bare false"));
+            process.exit(1);
+        }
 
         // Pass the "--force" flag to Git if specified
         await execa("git", ["worktree", "remove", ...(options.force ? ["--force"] : []), targetPath]);

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -39,4 +39,30 @@ export async function isWorktreeClean(worktreePath: string = "."): Promise<boole
     }
 }
 
-// Add other git-related utilities here in the future 
+// Add other git-related utilities here in the future
+
+export async function isMainRepoBare(cwd: string = '.'): Promise<boolean> {
+    try {
+        // Find the root of the git repository
+        const { stdout: gitDir } = await execa('git', ['-C', cwd, 'rev-parse', '--git-dir']);
+        const mainRepoDir = gitDir.endsWith('/.git') ? gitDir.slice(0, -5) : gitDir; // Handle bare repo paths vs normal .git
+
+        // Check the core.bare setting specifically for that repository path
+        const { stdout: bareConfig } = await execa('git', ['config', '--get', '--bool', 'core.bare'], {
+            cwd: mainRepoDir, // Check config in the main repo dir, not the potentially detached worktree CWD
+        });
+
+        // stdout will be 'true' or 'false' as a string
+        return bareConfig.trim() === 'true';
+    } catch (error: any) {
+        // If the command fails (e.g., not a git repo, or config not set),
+        // assume it's not bare, but log a warning.
+        // A non-existent core.bare config defaults to false.
+        if (error.exitCode === 1 && error.stdout === '' && error.stderr === '') {
+            // This specific exit code/output means the config key doesn't exist, which is fine (defaults to false).
+            return false;
+        }
+        console.warn(chalk.yellow(`Could not reliably determine if the main repository is bare. Proceeding cautiously. Error:`), error.stderr || error.message);
+        return false; // Default to non-bare to avoid blocking unnecessarily, but warn the user.
+    }
+} 


### PR DESCRIPTION
Adds safety checks to worktree commands: Checks core.bare config before add/remove. Requires clean main worktree for wt new. Prevents potential issues where the main repo could be accidentally marked as bare or operations run on an unclean state.