### PR TITLE
feat: add GitLab support for pr command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,20 @@ wt setup feature/new-feature
 wt setup feature/quick-start -i pnpm
 ```
 
-### Create a new worktree from Pull Request Number
+### Create a new worktree from Pull Request / Merge Request Number
 
 ```bash
 wt pr <prNumber> [options]
 ```
-Uses the GitHub CLI (`gh`) to check out the branch associated with the given Pull Request number, sets it up locally to track the correct remote branch (handling forks automatically), and then creates a worktree for it.
+Uses GitHub CLI (`gh`) or GitLab CLI (`glab`) to check out the branch associated with the given Pull Request or Merge Request number, sets it up locally to track the correct remote branch (handling forks automatically), and then creates a worktree for it.
 
-**Benefit:** Commits made in this worktree can be pushed directly using `git push` to update the Pull Request.
+**Benefit:** Commits made in this worktree can be pushed directly using `git push` to update the Pull Request or Merge Request.
 
-**Requires GitHub CLI (`gh`) to be installed and authenticated.**
+**Requires:**
+- **For GitHub**: GitHub CLI (`gh`) installed and authenticated
+- **For GitLab**: GitLab CLI (`glab`) installed and authenticated
+
+The tool automatically detects whether you're working with a GitHub or GitLab repository by analyzing the remote URL. You can also manually configure the preferred provider (see [Configure Git Provider](#configure-git-provider)).
 
 Options:
 - `-p, --path <path>`: Specify a custom path for the worktree (defaults to `<repoName>-<branchName>`)
@@ -68,10 +72,10 @@ Options:
 
 Example:
 ```bash
-# Create worktree for PR #123
+# Create worktree for PR/MR #123
 wt pr 123
 
-# Create worktree for PR #456, install deps with pnpm, open in vscode
+# Create worktree for PR/MR #456, install deps with pnpm, open in vscode
 wt pr 456 -i pnpm -e code
 ```
 
@@ -96,6 +100,24 @@ wt config path
 ```
 
 The default editor will be used when creating new worktrees unless overridden with the `-e` flag.
+
+### Configure Git Provider
+
+You can configure which Git provider CLI tool to use for the `wt pr` command:
+
+```bash
+# Set git provider
+wt config set provider <providerName>
+
+# Examples:
+wt config set provider gh    # Use GitHub CLI (default)
+wt config set provider glab  # Use GitLab CLI
+
+# Get current provider
+wt config get provider
+```
+
+**Note:** The tool automatically detects your Git provider by analyzing the remote URL (github.com or gitlab.com/gitlab.*). The configuration setting is only used as a fallback or when auto-detection is not possible.
 
 ### Setup Worktree Configuration
 
@@ -174,7 +196,9 @@ wt remove feature/chat
 - Git
 - Node.js
 - An editor installed and available in PATH (defaults to Cursor)
-- **GitHub CLI (`gh`) installed and authenticated (for `wt pr` command)**
+- **For `wt pr` command:**
+  - **GitHub**: GitHub CLI (`gh`) - install with `brew install gh`, authenticate with `gh auth login`
+  - **GitLab**: GitLab CLI (`glab`) - install with `brew install glab`, authenticate with `glab auth login`
 
 ## Development
 

--- a/build/commands/config.js
+++ b/build/commands/config.js
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { getDefaultEditor, setDefaultEditor, getConfigPath } from '../config.js';
+import { getDefaultEditor, setDefaultEditor, getGitProvider, setGitProvider, getConfigPath } from '../config.js';
 export async function configHandler(action, key, value) {
     try {
         switch (action) {
@@ -8,8 +8,13 @@ export async function configHandler(action, key, value) {
                     const editor = getDefaultEditor();
                     console.log(chalk.blue(`Default editor is currently set to: ${chalk.bold(editor)}`));
                 }
+                else if (key === 'provider') {
+                    const provider = getGitProvider();
+                    console.log(chalk.blue(`Git provider is currently set to: ${chalk.bold(provider)}`));
+                }
                 else {
                     console.error(chalk.red(`Unknown configuration key to get: ${key}`));
+                    console.error(chalk.yellow(`Available keys: editor, provider`));
                     process.exit(1);
                 }
                 break;
@@ -18,12 +23,26 @@ export async function configHandler(action, key, value) {
                     setDefaultEditor(value);
                     console.log(chalk.green(`Default editor set to: ${chalk.bold(value)}`));
                 }
+                else if (key === 'provider' && value) {
+                    if (value !== 'gh' && value !== 'glab') {
+                        console.error(chalk.red(`Invalid provider: ${value}`));
+                        console.error(chalk.yellow(`Valid providers: gh, glab`));
+                        process.exit(1);
+                    }
+                    setGitProvider(value);
+                    console.log(chalk.green(`Git provider set to: ${chalk.bold(value)}`));
+                }
                 else if (key === 'editor') {
                     console.error(chalk.red(`You must provide an editor name.`));
                     process.exit(1);
                 }
+                else if (key === 'provider') {
+                    console.error(chalk.red(`You must provide a provider (gh or glab).`));
+                    process.exit(1);
+                }
                 else {
                     console.error(chalk.red(`Unknown configuration key to set: ${key}`));
+                    console.error(chalk.yellow(`Available keys: editor, provider`));
                     process.exit(1);
                 }
                 break;

--- a/build/commands/merge.js
+++ b/build/commands/merge.js
@@ -1,6 +1,7 @@
 import { execa } from "execa";
 import chalk from "chalk";
 import { stat, rm } from "node:fs/promises";
+import { isMainRepoBare } from "../utils/git.js";
 export async function mergeWorktreeHandler(branchName, options) {
     try {
         // Validate that we're in a git repository
@@ -54,6 +55,12 @@ export async function mergeWorktreeHandler(branchName, options) {
         console.log(chalk.green(`Merged branch "${branchName}" into "${currentBranch}".`));
         // Step 3: Remove the worktree for the merged branch (similar to 'wt remove')
         console.log(chalk.blue(`Removing worktree for branch "${branchName}"...`));
+        if (await isMainRepoBare()) {
+            console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
+            console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
+            console.error(chalk.cyan("   git config core.bare false"));
+            process.exit(1);
+        }
         const removeArgs = ["worktree", "remove", ...(options.force ? ["--force"] : []), targetPath];
         await execa("git", removeArgs);
         console.log(chalk.green(`Removed worktree at ${targetPath}.`));

--- a/build/commands/pr.js
+++ b/build/commands/pr.js
@@ -2,35 +2,54 @@ import { execa } from "execa";
 import chalk from "chalk";
 import { stat } from "node:fs/promises";
 import { resolve, join, dirname, basename } from "node:path";
-import { getDefaultEditor } from "../config.js";
-import { getCurrentBranch, isWorktreeClean } from "../utils/git.js";
-// Helper function to get PR branch name using gh cli
-async function getBranchNameFromPR(prNumber) {
+import { getDefaultEditor, getGitProvider } from "../config.js";
+import { getCurrentBranch, isWorktreeClean, isMainRepoBare, detectGitProvider } from "../utils/git.js";
+// Helper function to get PR/MR branch name using gh or glab cli
+async function getBranchNameFromPR(prNumber, provider) {
     try {
-        // Use GitHub CLI to get the head ref name (branch name)
-        const { stdout } = await execa("gh", [
-            "pr",
-            "view",
-            prNumber,
-            "--json",
-            "headRefName",
-            "-q", // Suppress gh warnings if not tty
-            ".headRefName", // Query the JSON output for the branch name
-        ]);
-        const branchName = stdout.trim();
-        if (!branchName) {
-            throw new Error("Could not extract branch name from PR details.");
+        if (provider === 'gh') {
+            const { stdout } = await execa("gh", [
+                "pr",
+                "view",
+                prNumber,
+                "--json",
+                "headRefName",
+                "-q",
+                ".headRefName",
+            ]);
+            const branchName = stdout.trim();
+            if (!branchName) {
+                throw new Error("Could not extract branch name from PR details.");
+            }
+            return branchName;
         }
-        return branchName;
+        else {
+            const { stdout } = await execa("glab", [
+                "mr",
+                "view",
+                prNumber,
+                "-F",
+                "json",
+            ]);
+            const mrData = JSON.parse(stdout);
+            const branchName = mrData.source_branch;
+            if (!branchName) {
+                throw new Error("Could not extract branch name from MR details.");
+            }
+            return branchName;
+        }
     }
     catch (error) {
-        if (error.stderr?.includes("Could not find pull request")) {
-            throw new Error(`Pull Request #${prNumber} not found.`);
+        const isPR = provider === 'gh';
+        const requestType = isPR ? "Pull Request" : "Merge Request";
+        const cliName = isPR ? "gh" : "glab";
+        if (error.stderr?.includes("Could not find") || error.stderr?.includes("not found")) {
+            throw new Error(`${requestType} #${prNumber} not found.`);
         }
-        if (error.stderr?.includes("gh not found") || error.message?.includes("ENOENT")) {
-            throw new Error("GitHub CLI ('gh') not found. Please install it (brew install gh) and authenticate (gh auth login).");
+        if (error.stderr?.includes(`${cliName} not found`) || error.message?.includes("ENOENT")) {
+            throw new Error(`${isPR ? 'GitHub' : 'GitLab'} CLI ('${cliName}') not found. Please install it (brew install ${cliName}) and authenticate (${cliName} auth login).`);
         }
-        throw new Error(`Failed to get PR details: ${error.message || error.stderr || error}`);
+        throw new Error(`Failed to get ${requestType} details: ${error.message || error.stderr || error}`);
     }
 }
 export async function prWorktreeHandler(prNumber, options) {
@@ -38,72 +57,80 @@ export async function prWorktreeHandler(prNumber, options) {
     try {
         // 1. Validate we're in a git repo
         await execa("git", ["rev-parse", "--is-inside-work-tree"]);
+        // 2. Determine git provider (from config or auto-detect)
+        let provider = getGitProvider();
+        const detectedProvider = await detectGitProvider();
+        if (detectedProvider && detectedProvider !== provider) {
+            console.log(chalk.yellow(`Detected ${detectedProvider === 'gh' ? 'GitHub' : 'GitLab'} repository, but config is set to '${provider}'.`));
+            console.log(chalk.yellow(`Using detected provider: ${detectedProvider}`));
+            provider = detectedProvider;
+        }
+        const isPR = provider === 'gh';
+        const requestType = isPR ? "PR" : "MR";
         // ====> ADD THE CLEAN CHECK HERE <====
         console.log(chalk.blue("Checking if main worktree is clean..."));
         const isClean = await isWorktreeClean("."); // Check current directory (main worktree)
         if (!isClean) {
             console.error(chalk.red("❌ Error: Your main worktree is not clean."));
-            console.error(chalk.yellow("Running 'wt pr' requires a clean worktree to safely check out the PR branch temporarily."));
+            console.error(chalk.yellow(`Running 'wt pr' requires a clean worktree to safely check out the ${requestType} branch temporarily.`));
             console.error(chalk.yellow("Please commit, stash, or discard your changes in the main worktree."));
             console.error(chalk.cyan("Run 'git status' to see the changes."));
             process.exit(1); // Exit cleanly
         }
         console.log(chalk.green("✅ Main worktree is clean."));
         // ====> END OF CLEAN CHECK <====
-        // 2. Get current branch name to switch back later
+        // 3. Get current branch name to switch back later
         originalBranch = await getCurrentBranch();
         if (!originalBranch) {
             throw new Error("Could not determine the current branch. Ensure you are in a valid git repository.");
         }
         console.log(chalk.blue(`Current branch is "${originalBranch}".`));
-        // 3. Get the target branch name from the PR (needed for worktree add)
-        console.log(chalk.blue(`Fetching branch name for PR #${prNumber}...`));
-        const prBranchName = await getBranchNameFromPR(prNumber);
-        console.log(chalk.green(`PR head branch name: "${prBranchName}"`));
-        // 4. Use 'gh pr checkout' to fetch PR and setup tracking in the main worktree
-        console.log(chalk.blue(`Using 'gh pr checkout ${prNumber}' to fetch PR and set up local branch tracking...`));
+        // 4. Get the target branch name from the PR/MR (needed for worktree add)
+        console.log(chalk.blue(`Fetching branch name for ${requestType} #${prNumber}...`));
+        const prBranchName = await getBranchNameFromPR(prNumber, provider);
+        console.log(chalk.green(`${requestType} head branch name: "${prBranchName}"`));
+        // 5. Use 'gh pr checkout' or 'glab mr checkout' to fetch and setup tracking in the main worktree
+        const cliName = isPR ? 'gh' : 'glab';
+        const subCommand = isPR ? 'pr' : 'mr';
+        console.log(chalk.blue(`Using '${cliName} ${subCommand} checkout ${prNumber}' to fetch ${requestType} and set up local branch tracking...`));
         try {
-            await execa("gh", ["pr", "checkout", prNumber], { stdio: 'pipe' }); // Use pipe to capture output/errors if needed
-            console.log(chalk.green(`Successfully checked out PR #${prNumber} branch "${prBranchName}" locally.`));
+            await execa(cliName, [subCommand, "checkout", prNumber], { stdio: 'pipe' });
+            console.log(chalk.green(`Successfully checked out ${requestType} #${prNumber} branch "${prBranchName}" locally.`));
         }
-        catch (ghError) {
-            if (ghError.stderr?.includes("is already checked out")) {
-                console.log(chalk.yellow(`Branch "${prBranchName}" for PR #${prNumber} is already checked out.`));
-                // It's already checked out, we might not need to switch, but ensure tracking is set
-                // 'gh pr checkout' likely handled tracking. We'll proceed.
+        catch (checkoutError) {
+            if (checkoutError.stderr?.includes("is already checked out")) {
+                console.log(chalk.yellow(`Branch "${prBranchName}" for ${requestType} #${prNumber} is already checked out.`));
             }
-            else if (ghError.stderr?.includes("Could not find pull request")) {
-                throw new Error(`Pull Request #${prNumber} not found.`);
+            else if (checkoutError.stderr?.includes("Could not find")) {
+                throw new Error(`${isPR ? 'Pull Request' : 'Merge Request'} #${prNumber} not found.`);
             }
-            else if (ghError.stderr?.includes("gh not found") || ghError.message?.includes("ENOENT")) {
-                throw new Error("GitHub CLI ('gh') not found. Please install it (brew install gh) and authenticate (gh auth login).");
+            else if (checkoutError.stderr?.includes(`${cliName} not found`) || checkoutError.message?.includes("ENOENT")) {
+                throw new Error(`${isPR ? 'GitHub' : 'GitLab'} CLI ('${cliName}') not found. Please install it (brew install ${cliName}) and authenticate (${cliName} auth login).`);
             }
             else {
-                console.error(chalk.red("Error during 'gh pr checkout':"), ghError.stderr || ghError.stdout || ghError.message);
-                throw new Error(`Failed to checkout PR using gh: ${ghError.message}`);
+                console.error(chalk.red(`Error during '${cliName} ${subCommand} checkout':`), checkoutError.stderr || checkoutError.stdout || checkoutError.message);
+                throw new Error(`Failed to checkout ${requestType} using ${cliName}: ${checkoutError.message}`);
             }
         }
-        // 4.5 Switch back to original branch IMMEDIATELY after gh checkout ensures the main worktree is clean
+        // 6. Switch back to original branch IMMEDIATELY after checkout ensures the main worktree is clean
         if (originalBranch) {
             try {
-                const currentBranchAfterGh = await getCurrentBranch();
-                if (currentBranchAfterGh === prBranchName && currentBranchAfterGh !== originalBranch) {
+                const currentBranchAfterCheckout = await getCurrentBranch();
+                if (currentBranchAfterCheckout === prBranchName && currentBranchAfterCheckout !== originalBranch) {
                     console.log(chalk.blue(`Switching main worktree back to "${originalBranch}" before creating worktree...`));
                     await execa("git", ["checkout", originalBranch]);
                 }
-                else if (currentBranchAfterGh !== originalBranch) {
-                    console.log(chalk.yellow(`Current branch is ${currentBranchAfterGh}, not ${prBranchName}. Assuming gh handled checkout correctly.`));
-                    // If gh failed but left us on a different branch, still try to go back
+                else if (currentBranchAfterCheckout !== originalBranch) {
+                    console.log(chalk.yellow(`Current branch is ${currentBranchAfterCheckout}, not ${prBranchName}. Assuming ${cliName} handled checkout correctly.`));
                     await execa("git", ["checkout", originalBranch]);
                 }
             }
             catch (checkoutError) {
-                console.warn(chalk.yellow(`⚠️ Warning: Failed to switch main worktree back to original branch "${originalBranch}" after gh checkout. Please check manually.`));
+                console.warn(chalk.yellow(`⚠️ Warning: Failed to switch main worktree back to original branch "${originalBranch}" after ${cliName} checkout. Please check manually.`));
                 console.warn(checkoutError.stderr || checkoutError.message);
-                // Proceed with caution, worktree add might fail
             }
         }
-        // 5. Build final path for the new worktree
+        // 7. Build final path for the new worktree
         let folderName;
         if (options.path) {
             folderName = options.path;
@@ -112,11 +139,11 @@ export async function prWorktreeHandler(prNumber, options) {
             const currentDir = process.cwd();
             const parentDir = dirname(currentDir);
             const currentDirName = basename(currentDir);
-            const sanitizedBranchName = prBranchName.replace(/\//g, '-'); // Use PR branch name for consistency
+            const sanitizedBranchName = prBranchName.replace(/\//g, '-');
             folderName = join(parentDir, `${currentDirName}-${sanitizedBranchName}`);
         }
         const resolvedPath = resolve(folderName);
-        // 6. Check if directory already exists
+        // 8. Check if directory already exists
         let directoryExists = false;
         try {
             await stat(resolvedPath);
@@ -151,24 +178,26 @@ export async function prWorktreeHandler(prNumber, options) {
             }
         }
         else {
-            // 7. Create the worktree using the PR branch (now only fetched/tracked, not checked out here)
+            // 9. Create the worktree using the PR/MR branch (now only fetched/tracked, not checked out here)
             console.log(chalk.blue(`Creating new worktree for branch "${prBranchName}" at: ${resolvedPath}`));
             try {
-                // Use the PR branch name which 'gh pr checkout' fetched/tracked locally
+                if (await isMainRepoBare()) {
+                    console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
+                    console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
+                    console.error(chalk.cyan("   git config core.bare false"));
+                    process.exit(1);
+                }
                 await execa("git", ["worktree", "add", resolvedPath, prBranchName]);
                 worktreeCreated = true;
             }
             catch (worktreeError) {
-                // The "already checked out" error should ideally not happen with the new flow.
-                // Handle other potential worktree add errors.
                 console.error(chalk.red(`❌ Failed to create worktree for branch "${prBranchName}" at ${resolvedPath}:`), worktreeError.stderr || worktreeError.message);
-                // Suggest checking if the branch exists locally if it fails
                 if (worktreeError.stderr?.includes("fatal:")) {
                     console.error(chalk.cyan(`   Suggestion: Verify branch "${prBranchName}" exists locally ('git branch') and the path "${resolvedPath}" is valid and empty.`));
                 }
-                throw worktreeError; // Rethrow to trigger main catch block and cleanup
+                throw worktreeError;
             }
-            // 8. (Optional) Install dependencies
+            // 10. (Optional) Install dependencies
             if (options.install) {
                 console.log(chalk.blue(`Installing dependencies using ${options.install} in ${resolvedPath}...`));
                 // Add error handling for install step if desired
@@ -182,32 +211,31 @@ export async function prWorktreeHandler(prNumber, options) {
                 }
             }
         }
-        // 9. Open in editor
+        // 11. Open in editor
         const configuredEditor = getDefaultEditor();
         const editorCommand = options.editor || configuredEditor;
         console.log(chalk.blue(`Opening ${resolvedPath} in ${editorCommand}...`));
         try {
-            await execa(editorCommand, [resolvedPath], { stdio: "ignore", detached: true }); // Detach editor process
+            await execa(editorCommand, [resolvedPath], { stdio: "ignore", detached: true });
         }
         catch (editorError) {
             console.error(chalk.red(`Failed to open editor "${editorCommand}". Please ensure it's installed and in your PATH.`));
             console.warn(chalk.yellow(`Worktree is ready at ${resolvedPath}. You can open it manually.`));
         }
-        console.log(chalk.green(`✅ Worktree for PR #${prNumber} (${prBranchName}) ${worktreeCreated ? "created" : "found"} at ${resolvedPath}.`));
+        console.log(chalk.green(`✅ Worktree for ${requestType} #${prNumber} (${prBranchName}) ${worktreeCreated ? "created" : "found"} at ${resolvedPath}.`));
         if (worktreeCreated && options.install)
             console.log(chalk.green(`   Dependencies installed using ${options.install}.`));
-        console.log(chalk.green(`   Ready for work. Use 'git push' inside the worktree directory to update the PR.`));
+        console.log(chalk.green(`   Ready for work. Use 'git push' inside the worktree directory to update the ${requestType}.`));
     }
     catch (error) {
-        console.error(chalk.red("❌ Failed to set up worktree from PR:"), error.message || error);
-        if (error.stack && !(error.stderr || error.stdout)) { // Avoid printing stack for execa errors if stderr/stdout is present
+        console.error(chalk.red("❌ Failed to set up worktree from PR/MR:"), error.message || error);
+        if (error.stack && !(error.stderr || error.stdout)) {
             console.error(error.stack);
         }
         process.exit(1);
     }
     finally {
-        // 10. Ensure we are back on the original branch in the main worktree
-        // This is now mostly a safeguard, as we attempted to switch back earlier.
+        // 12. Ensure we are back on the original branch in the main worktree
         if (originalBranch) {
             try {
                 const currentBranchNow = await getCurrentBranch();
@@ -217,8 +245,7 @@ export async function prWorktreeHandler(prNumber, options) {
                 }
             }
             catch (checkoutError) {
-                // Don't warn again if the previous attempt already warned
-                if (!checkoutError.message.includes("already warned")) { // Avoid redundant warnings
+                if (!checkoutError.message.includes("already warned")) {
                     console.warn(chalk.yellow(`⚠️ Warning: Final check failed to switch main worktree back to original branch "${originalBranch}". Please check manually.`));
                     console.warn(checkoutError.stderr || checkoutError.message);
                 }

--- a/build/config.js
+++ b/build/config.js
@@ -14,6 +14,11 @@ const schema = {
         type: 'string',
         default: 'cursor', // Default editor is 'cursor'
     },
+    gitProvider: {
+        type: 'string',
+        enum: ['gh', 'glab'],
+        default: 'gh', // Default provider is GitHub CLI
+    },
 };
 const config = new Conf({
     projectName: packageName, // Use the actual package name
@@ -26,6 +31,14 @@ export function getDefaultEditor() {
 // Function to set the default editor
 export function setDefaultEditor(editor) {
     config.set('defaultEditor', editor);
+}
+// Function to get the git provider
+export function getGitProvider() {
+    return config.get('gitProvider');
+}
+// Function to set the git provider
+export function setGitProvider(provider) {
+    config.set('gitProvider', provider);
 }
 // Function to get the path to the config file (for debugging/info)
 export function getConfigPath() {

--- a/build/index.js
+++ b/build/index.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { newWorktreeHandler } from "./commands/new.js";
+import { setupWorktreeHandler } from "./commands/setup.js";
 import { listWorktreesHandler } from "./commands/list.js";
 import { removeWorktreeHandler } from "./commands/remove.js";
 import { mergeWorktreeHandler } from "./commands/merge.js";
 import { purgeWorktreesHandler } from "./commands/purge.js";
 import { configHandler } from "./commands/config.js";
 import { prWorktreeHandler } from "./commands/pr.js";
+import { openWorktreeHandler } from "./commands/open.js";
+import { extractWorktreeHandler } from "./commands/extract.js";
 const program = new Command();
 program
     .name("wt")
@@ -21,6 +24,15 @@ program
     .option("-e, --editor <editor>", "Editor to use for opening the worktree (e.g., code, webstorm, windsurf, etc.)")
     .description("Create a new worktree for the specified branch, install dependencies if specified, and open in editor.")
     .action(newWorktreeHandler);
+program
+    .command("setup")
+    .argument("[branchName]", "Name of the branch to base this worktree on")
+    .option("-p, --path <path>", "Relative path/folder name for new worktree")
+    .option("-c, --checkout", "Create new branch if it doesn't exist and checkout automatically", false)
+    .option("-i, --install <packageManager>", "Package manager to use for installing dependencies (npm, pnpm, bun, etc.)")
+    .option("-e, --editor <editor>", "Editor to use for opening the worktree (e.g., code, webstorm, windsurf, etc.)")
+    .description("Create a new worktree and run setup scripts from worktrees.json or .cursor/worktrees.json")
+    .action(setupWorktreeHandler);
 program
     .command("list")
     .alias("ls")
@@ -52,6 +64,20 @@ program
     .description("Fetch the branch for a given GitHub PR number and create a worktree.")
     .action(prWorktreeHandler);
 program
+    .command("open")
+    .argument("[pathOrBranch]", "Path to worktree or branch name to open")
+    .option("-e, --editor <editor>", "Editor to use for opening the worktree (overrides default editor)")
+    .description("Open an existing worktree in the editor.")
+    .action(openWorktreeHandler);
+program
+    .command("extract")
+    .argument("[branchName]", "Name of the branch to extract (defaults to current branch)")
+    .option("-p, --path <path>", "Relative path/folder name for the worktree")
+    .option("-i, --install <packageManager>", "Package manager to use for installing dependencies (npm, pnpm, bun, etc.)")
+    .option("-e, --editor <editor>", "Editor to use for opening the worktree (overrides default editor)")
+    .description("Extract an existing branch as a new worktree. If no branch is specified, extracts the current branch.")
+    .action(extractWorktreeHandler);
+program
     .command("config")
     .description("Manage CLI configuration settings.")
     .addCommand(new Command("set")
@@ -59,13 +85,20 @@ program
     .addCommand(new Command("editor")
     .argument("<editorName>", "Name of the editor command (e.g., code, cursor, webstorm)")
     .description("Set the default editor to open worktrees in.")
-    .action((editorName) => configHandler('set', 'editor', editorName))))
+    .action((editorName) => configHandler("set", "editor", editorName)))
+    .addCommand(new Command("provider")
+    .argument("<providerName>", "Git provider CLI to use (gh for GitHub, glab for GitLab)")
+    .description("Set the default git provider (gh or glab).")
+    .action((providerName) => configHandler("set", "provider", providerName))))
     .addCommand(new Command("get")
     .description("Get a configuration value.")
     .addCommand(new Command("editor")
     .description("Get the currently configured default editor.")
-    .action(() => configHandler('get', 'editor'))))
+    .action(() => configHandler("get", "editor")))
+    .addCommand(new Command("provider")
+    .description("Get the currently configured git provider.")
+    .action(() => configHandler("get", "provider"))))
     .addCommand(new Command("path")
     .description("Show the path to the configuration file.")
-    .action(() => configHandler('path')));
+    .action(() => configHandler("path")));
 program.parse(process.argv);

--- a/build/utils/git.js
+++ b/build/utils/git.js
@@ -38,4 +38,55 @@ export async function isWorktreeClean(worktreePath = ".") {
         return false;
     }
 }
-// Add other git-related utilities here in the future 
+// Add other git-related utilities here in the future
+export async function isMainRepoBare(cwd = '.') {
+    try {
+        // Find the root of the git repository
+        const { stdout: gitDir } = await execa('git', ['-C', cwd, 'rev-parse', '--git-dir']);
+        const mainRepoDir = gitDir.endsWith('/.git') ? gitDir.slice(0, -5) : gitDir; // Handle bare repo paths vs normal .git
+        // Check the core.bare setting specifically for that repository path
+        const { stdout: bareConfig } = await execa('git', ['config', '--get', '--bool', 'core.bare'], {
+            cwd: mainRepoDir, // Check config in the main repo dir, not the potentially detached worktree CWD
+        });
+        // stdout will be 'true' or 'false' as a string
+        return bareConfig.trim() === 'true';
+    }
+    catch (error) {
+        // If the command fails (e.g., not a git repo, or config not set),
+        // assume it's not bare, but log a warning.
+        // A non-existent core.bare config defaults to false.
+        if (error.exitCode === 1 && error.stdout === '' && error.stderr === '') {
+            // This specific exit code/output means the config key doesn't exist, which is fine (defaults to false).
+            return false;
+        }
+        console.warn(chalk.yellow(`Could not reliably determine if the main repository is bare. Proceeding cautiously. Error:`), error.stderr || error.message);
+        return false; // Default to non-bare to avoid blocking unnecessarily, but warn the user.
+    }
+}
+export async function getRepoRoot(cwd = ".") {
+    try {
+        const { stdout } = await execa("git", ["-C", cwd, "rev-parse", "--show-toplevel"]);
+        return stdout.trim();
+    }
+    catch (error) {
+        console.error(chalk.yellow("Could not determine repository root."), error);
+        return null;
+    }
+}
+export async function detectGitProvider(cwd = ".") {
+    try {
+        const { stdout } = await execa("git", ["-C", cwd, "remote", "get-url", "origin"]);
+        const remoteUrl = stdout.trim();
+        if (remoteUrl.includes('github.com')) {
+            return 'gh';
+        }
+        else if (remoteUrl.includes('gitlab.com') || remoteUrl.includes('gitlab')) {
+            return 'glab';
+        }
+        return null;
+    }
+    catch (error) {
+        console.error(chalk.yellow("Could not detect git provider from remote."), error);
+        return null;
+    }
+}

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { getDefaultEditor, setDefaultEditor, getConfigPath } from '../config.js';
+import { getDefaultEditor, setDefaultEditor, getGitProvider, setGitProvider, getConfigPath } from '../config.js';
 
 export async function configHandler(action: 'get' | 'set' | 'path', key?: string, value?: string) {
     try {
@@ -8,8 +8,12 @@ export async function configHandler(action: 'get' | 'set' | 'path', key?: string
                 if (key === 'editor') {
                     const editor = getDefaultEditor();
                     console.log(chalk.blue(`Default editor is currently set to: ${chalk.bold(editor)}`));
+                } else if (key === 'provider') {
+                    const provider = getGitProvider();
+                    console.log(chalk.blue(`Git provider is currently set to: ${chalk.bold(provider)}`));
                 } else {
                     console.error(chalk.red(`Unknown configuration key to get: ${key}`));
+                    console.error(chalk.yellow(`Available keys: editor, provider`));
                     process.exit(1);
                 }
                 break;
@@ -17,11 +21,23 @@ export async function configHandler(action: 'get' | 'set' | 'path', key?: string
                 if (key === 'editor' && value) {
                     setDefaultEditor(value);
                     console.log(chalk.green(`Default editor set to: ${chalk.bold(value)}`));
+                } else if (key === 'provider' && value) {
+                    if (value !== 'gh' && value !== 'glab') {
+                        console.error(chalk.red(`Invalid provider: ${value}`));
+                        console.error(chalk.yellow(`Valid providers: gh, glab`));
+                        process.exit(1);
+                    }
+                    setGitProvider(value as 'gh' | 'glab');
+                    console.log(chalk.green(`Git provider set to: ${chalk.bold(value)}`));
                 } else if (key === 'editor') {
                     console.error(chalk.red(`You must provide an editor name.`));
                     process.exit(1);
+                } else if (key === 'provider') {
+                    console.error(chalk.red(`You must provide a provider (gh or glab).`));
+                    process.exit(1);
                 } else {
                     console.error(chalk.red(`Unknown configuration key to set: ${key}`));
+                    console.error(chalk.yellow(`Available keys: editor, provider`));
                     process.exit(1);
                 }
                 break;

--- a/src/commands/pr.ts
+++ b/src/commands/pr.ts
@@ -2,35 +2,56 @@ import { execa } from "execa";
 import chalk from "chalk";
 import { stat } from "node:fs/promises";
 import { resolve, join, dirname, basename } from "node:path";
-import { getDefaultEditor } from "../config.js";
-import { getCurrentBranch, isWorktreeClean, isMainRepoBare } from "../utils/git.js";
+import { getDefaultEditor, getGitProvider } from "../config.js";
+import { getCurrentBranch, isWorktreeClean, isMainRepoBare, detectGitProvider } from "../utils/git.js";
 
-// Helper function to get PR branch name using gh cli
-async function getBranchNameFromPR(prNumber: string): Promise<string> {
+type GitProvider = 'gh' | 'glab';
+
+// Helper function to get PR/MR branch name using gh or glab cli
+async function getBranchNameFromPR(prNumber: string, provider: GitProvider): Promise<string> {
     try {
-        // Use GitHub CLI to get the head ref name (branch name)
-        const { stdout } = await execa("gh", [
-            "pr",
-            "view",
-            prNumber,
-            "--json",
-            "headRefName",
-            "-q", // Suppress gh warnings if not tty
-            ".headRefName", // Query the JSON output for the branch name
-        ]);
-        const branchName = stdout.trim();
-        if (!branchName) {
-            throw new Error("Could not extract branch name from PR details.");
+        if (provider === 'gh') {
+            const { stdout } = await execa("gh", [
+                "pr",
+                "view",
+                prNumber,
+                "--json",
+                "headRefName",
+                "-q",
+                ".headRefName",
+            ]);
+            const branchName = stdout.trim();
+            if (!branchName) {
+                throw new Error("Could not extract branch name from PR details.");
+            }
+            return branchName;
+        } else {
+            const { stdout } = await execa("glab", [
+                "mr",
+                "view",
+                prNumber,
+                "-F",
+                "json",
+            ]);
+            const mrData = JSON.parse(stdout);
+            const branchName = mrData.source_branch;
+            if (!branchName) {
+                throw new Error("Could not extract branch name from MR details.");
+            }
+            return branchName;
         }
-        return branchName;
     } catch (error: any) {
-        if (error.stderr?.includes("Could not find pull request")) {
-            throw new Error(`Pull Request #${prNumber} not found.`);
+        const isPR = provider === 'gh';
+        const requestType = isPR ? "Pull Request" : "Merge Request";
+        const cliName = isPR ? "gh" : "glab";
+
+        if (error.stderr?.includes("Could not find") || error.stderr?.includes("not found")) {
+            throw new Error(`${requestType} #${prNumber} not found.`);
         }
-        if (error.stderr?.includes("gh not found") || error.message?.includes("ENOENT")) {
-            throw new Error("GitHub CLI ('gh') not found. Please install it (brew install gh) and authenticate (gh auth login).");
+        if (error.stderr?.includes(`${cliName} not found`) || error.message?.includes("ENOENT")) {
+            throw new Error(`${isPR ? 'GitHub' : 'GitLab'} CLI ('${cliName}') not found. Please install it (brew install ${cliName}) and authenticate (${cliName} auth login).`);
         }
-        throw new Error(`Failed to get PR details: ${error.message || error.stderr || error}`);
+        throw new Error(`Failed to get ${requestType} details: ${error.message || error.stderr || error}`);
     }
 }
 
@@ -44,12 +65,23 @@ export async function prWorktreeHandler(
         // 1. Validate we're in a git repo
         await execa("git", ["rev-parse", "--is-inside-work-tree"]);
 
+        // 2. Determine git provider (from config or auto-detect)
+        let provider = getGitProvider();
+        const detectedProvider = await detectGitProvider();
+        if (detectedProvider && detectedProvider !== provider) {
+            console.log(chalk.yellow(`Detected ${detectedProvider === 'gh' ? 'GitHub' : 'GitLab'} repository, but config is set to '${provider}'.`));
+            console.log(chalk.yellow(`Using detected provider: ${detectedProvider}`));
+            provider = detectedProvider;
+        }
+        const isPR = provider === 'gh';
+        const requestType = isPR ? "PR" : "MR";
+
         // ====> ADD THE CLEAN CHECK HERE <====
         console.log(chalk.blue("Checking if main worktree is clean..."));
         const isClean = await isWorktreeClean("."); // Check current directory (main worktree)
         if (!isClean) {
             console.error(chalk.red("❌ Error: Your main worktree is not clean."));
-            console.error(chalk.yellow("Running 'wt pr' requires a clean worktree to safely check out the PR branch temporarily."));
+            console.error(chalk.yellow(`Running 'wt pr' requires a clean worktree to safely check out the ${requestType} branch temporarily.`));
             console.error(chalk.yellow("Please commit, stash, or discard your changes in the main worktree."));
             console.error(chalk.cyan("Run 'git status' to see the changes."));
             process.exit(1); // Exit cleanly
@@ -57,7 +89,7 @@ export async function prWorktreeHandler(
         console.log(chalk.green("✅ Main worktree is clean."));
         // ====> END OF CLEAN CHECK <====
 
-        // 2. Get current branch name to switch back later
+        // 3. Get current branch name to switch back later
         originalBranch = await getCurrentBranch();
         if (!originalBranch) {
             throw new Error("Could not determine the current branch. Ensure you are in a valid git repository.");
@@ -65,51 +97,49 @@ export async function prWorktreeHandler(
         console.log(chalk.blue(`Current branch is "${originalBranch}".`));
 
 
-        // 3. Get the target branch name from the PR (needed for worktree add)
-        console.log(chalk.blue(`Fetching branch name for PR #${prNumber}...`));
-        const prBranchName = await getBranchNameFromPR(prNumber);
-        console.log(chalk.green(`PR head branch name: "${prBranchName}"`));
+        // 4. Get the target branch name from the PR/MR (needed for worktree add)
+        console.log(chalk.blue(`Fetching branch name for ${requestType} #${prNumber}...`));
+        const prBranchName = await getBranchNameFromPR(prNumber, provider);
+        console.log(chalk.green(`${requestType} head branch name: "${prBranchName}"`));
 
-        // 4. Use 'gh pr checkout' to fetch PR and setup tracking in the main worktree
-        console.log(chalk.blue(`Using 'gh pr checkout ${prNumber}' to fetch PR and set up local branch tracking...`));
+        // 5. Use 'gh pr checkout' or 'glab mr checkout' to fetch and setup tracking in the main worktree
+        const cliName = isPR ? 'gh' : 'glab';
+        const subCommand = isPR ? 'pr' : 'mr';
+        console.log(chalk.blue(`Using '${cliName} ${subCommand} checkout ${prNumber}' to fetch ${requestType} and set up local branch tracking...`));
         try {
-            await execa("gh", ["pr", "checkout", prNumber], { stdio: 'pipe' }); // Use pipe to capture output/errors if needed
-            console.log(chalk.green(`Successfully checked out PR #${prNumber} branch "${prBranchName}" locally.`));
-        } catch (ghError: any) {
-            if (ghError.stderr?.includes("is already checked out")) {
-                console.log(chalk.yellow(`Branch "${prBranchName}" for PR #${prNumber} is already checked out.`));
-                // It's already checked out, we might not need to switch, but ensure tracking is set
-                // 'gh pr checkout' likely handled tracking. We'll proceed.
-            } else if (ghError.stderr?.includes("Could not find pull request")) {
-                throw new Error(`Pull Request #${prNumber} not found.`);
-            } else if (ghError.stderr?.includes("gh not found") || ghError.message?.includes("ENOENT")) {
-                throw new Error("GitHub CLI ('gh') not found. Please install it (brew install gh) and authenticate (gh auth login).");
+            await execa(cliName, [subCommand, "checkout", prNumber], { stdio: 'pipe' });
+            console.log(chalk.green(`Successfully checked out ${requestType} #${prNumber} branch "${prBranchName}" locally.`));
+        } catch (checkoutError: any) {
+            if (checkoutError.stderr?.includes("is already checked out")) {
+                console.log(chalk.yellow(`Branch "${prBranchName}" for ${requestType} #${prNumber} is already checked out.`));
+            } else if (checkoutError.stderr?.includes("Could not find")) {
+                throw new Error(`${isPR ? 'Pull Request' : 'Merge Request'} #${prNumber} not found.`);
+            } else if (checkoutError.stderr?.includes(`${cliName} not found`) || checkoutError.message?.includes("ENOENT")) {
+                throw new Error(`${isPR ? 'GitHub' : 'GitLab'} CLI ('${cliName}') not found. Please install it (brew install ${cliName}) and authenticate (${cliName} auth login).`);
             } else {
-                console.error(chalk.red("Error during 'gh pr checkout':"), ghError.stderr || ghError.stdout || ghError.message);
-                throw new Error(`Failed to checkout PR using gh: ${ghError.message}`);
+                console.error(chalk.red(`Error during '${cliName} ${subCommand} checkout':`), checkoutError.stderr || checkoutError.stdout || checkoutError.message);
+                throw new Error(`Failed to checkout ${requestType} using ${cliName}: ${checkoutError.message}`);
             }
         }
 
-        // 4.5 Switch back to original branch IMMEDIATELY after gh checkout ensures the main worktree is clean
+        // 6. Switch back to original branch IMMEDIATELY after checkout ensures the main worktree is clean
         if (originalBranch) {
             try {
-                const currentBranchAfterGh = await getCurrentBranch();
-                if (currentBranchAfterGh === prBranchName && currentBranchAfterGh !== originalBranch) {
+                const currentBranchAfterCheckout = await getCurrentBranch();
+                if (currentBranchAfterCheckout === prBranchName && currentBranchAfterCheckout !== originalBranch) {
                     console.log(chalk.blue(`Switching main worktree back to "${originalBranch}" before creating worktree...`));
                     await execa("git", ["checkout", originalBranch]);
-                } else if (currentBranchAfterGh !== originalBranch) {
-                    console.log(chalk.yellow(`Current branch is ${currentBranchAfterGh}, not ${prBranchName}. Assuming gh handled checkout correctly.`));
-                    // If gh failed but left us on a different branch, still try to go back
+                } else if (currentBranchAfterCheckout !== originalBranch) {
+                    console.log(chalk.yellow(`Current branch is ${currentBranchAfterCheckout}, not ${prBranchName}. Assuming ${cliName} handled checkout correctly.`));
                     await execa("git", ["checkout", originalBranch]);
                 }
             } catch (checkoutError: any) {
-                console.warn(chalk.yellow(`⚠️ Warning: Failed to switch main worktree back to original branch "${originalBranch}" after gh checkout. Please check manually.`));
+                console.warn(chalk.yellow(`⚠️ Warning: Failed to switch main worktree back to original branch "${originalBranch}" after ${cliName} checkout. Please check manually.`));
                 console.warn(checkoutError.stderr || checkoutError.message);
-                // Proceed with caution, worktree add might fail
             }
         }
 
-        // 5. Build final path for the new worktree
+        // 7. Build final path for the new worktree
         let folderName: string;
         if (options.path) {
             folderName = options.path;
@@ -117,12 +147,12 @@ export async function prWorktreeHandler(
             const currentDir = process.cwd();
             const parentDir = dirname(currentDir);
             const currentDirName = basename(currentDir);
-            const sanitizedBranchName = prBranchName.replace(/\//g, '-'); // Use PR branch name for consistency
+            const sanitizedBranchName = prBranchName.replace(/\//g, '-');
             folderName = join(parentDir, `${currentDirName}-${sanitizedBranchName}`);
         }
         const resolvedPath = resolve(folderName);
 
-        // 6. Check if directory already exists
+        // 8. Check if directory already exists
         let directoryExists = false;
         try {
             await stat(resolvedPath);
@@ -153,31 +183,26 @@ export async function prWorktreeHandler(
                 process.exit(1);
             }
         } else {
-            // 7. Create the worktree using the PR branch (now only fetched/tracked, not checked out here)
+            // 9. Create the worktree using the PR/MR branch (now only fetched/tracked, not checked out here)
             console.log(chalk.blue(`Creating new worktree for branch "${prBranchName}" at: ${resolvedPath}`));
             try {
-                // >>> ADD SAFETY CHECK HERE <<<
                 if (await isMainRepoBare()) {
                     console.error(chalk.red("❌ Error: The main repository is configured as 'bare' (core.bare=true)."));
                     console.error(chalk.red("   This prevents normal Git operations. Please fix the configuration:"));
                     console.error(chalk.cyan("   git config core.bare false"));
                     process.exit(1);
                 }
-                // Use the PR branch name which 'gh pr checkout' fetched/tracked locally
                 await execa("git", ["worktree", "add", resolvedPath, prBranchName]);
                 worktreeCreated = true;
             } catch (worktreeError: any) {
-                // The "already checked out" error should ideally not happen with the new flow.
-                // Handle other potential worktree add errors.
                 console.error(chalk.red(`❌ Failed to create worktree for branch "${prBranchName}" at ${resolvedPath}:`), worktreeError.stderr || worktreeError.message);
-                // Suggest checking if the branch exists locally if it fails
                 if (worktreeError.stderr?.includes("fatal:")) {
                     console.error(chalk.cyan(`   Suggestion: Verify branch "${prBranchName}" exists locally ('git branch') and the path "${resolvedPath}" is valid and empty.`));
                 }
-                throw worktreeError; // Rethrow to trigger main catch block and cleanup
+                throw worktreeError;
             }
 
-            // 8. (Optional) Install dependencies
+            // 10. (Optional) Install dependencies
             if (options.install) {
                 console.log(chalk.blue(`Installing dependencies using ${options.install} in ${resolvedPath}...`));
                 // Add error handling for install step if desired
@@ -191,31 +216,30 @@ export async function prWorktreeHandler(
             }
         }
 
-        // 9. Open in editor
+        // 11. Open in editor
         const configuredEditor = getDefaultEditor();
         const editorCommand = options.editor || configuredEditor;
         console.log(chalk.blue(`Opening ${resolvedPath} in ${editorCommand}...`));
         try {
-            await execa(editorCommand, [resolvedPath], { stdio: "ignore", detached: true }); // Detach editor process
+            await execa(editorCommand, [resolvedPath], { stdio: "ignore", detached: true });
         } catch (editorError) {
             console.error(chalk.red(`Failed to open editor "${editorCommand}". Please ensure it's installed and in your PATH.`));
             console.warn(chalk.yellow(`Worktree is ready at ${resolvedPath}. You can open it manually.`));
         }
 
-        console.log(chalk.green(`✅ Worktree for PR #${prNumber} (${prBranchName}) ${worktreeCreated ? "created" : "found"} at ${resolvedPath}.`));
+        console.log(chalk.green(`✅ Worktree for ${requestType} #${prNumber} (${prBranchName}) ${worktreeCreated ? "created" : "found"} at ${resolvedPath}.`));
         if (worktreeCreated && options.install) console.log(chalk.green(`   Dependencies installed using ${options.install}.`));
-        console.log(chalk.green(`   Ready for work. Use 'git push' inside the worktree directory to update the PR.`));
+        console.log(chalk.green(`   Ready for work. Use 'git push' inside the worktree directory to update the ${requestType}.`));
 
 
     } catch (error: any) {
-        console.error(chalk.red("❌ Failed to set up worktree from PR:"), error.message || error);
-        if (error.stack && !(error.stderr || error.stdout)) { // Avoid printing stack for execa errors if stderr/stdout is present
+        console.error(chalk.red("❌ Failed to set up worktree from PR/MR:"), error.message || error);
+        if (error.stack && !(error.stderr || error.stdout)) {
             console.error(error.stack);
         }
         process.exit(1);
     } finally {
-        // 10. Ensure we are back on the original branch in the main worktree
-        // This is now mostly a safeguard, as we attempted to switch back earlier.
+        // 12. Ensure we are back on the original branch in the main worktree
         if (originalBranch) {
             try {
                 const currentBranchNow = await getCurrentBranch();
@@ -224,8 +248,7 @@ export async function prWorktreeHandler(
                     await execa("git", ["checkout", originalBranch]);
                 }
             } catch (checkoutError: any) {
-                // Don't warn again if the previous attempt already warned
-                if (!checkoutError.message.includes("already warned")) { // Avoid redundant warnings
+                if (!checkoutError.message.includes("already warned")) {
                     console.warn(chalk.yellow(`⚠️ Warning: Final check failed to switch main worktree back to original branch "${originalBranch}". Please check manually.`));
                     console.warn(checkoutError.stderr || checkoutError.message);
                 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const packageName = packageJson.name;
 // Define the structure of the configuration
 interface ConfigSchema {
     defaultEditor: string;
+    gitProvider: 'gh' | 'glab';
 }
 
 // Initialize conf with a schema and project name
@@ -20,6 +21,11 @@ const schema = {
     defaultEditor: {
         type: 'string',
         default: 'cursor', // Default editor is 'cursor'
+    },
+    gitProvider: {
+        type: 'string',
+        enum: ['gh', 'glab'],
+        default: 'gh', // Default provider is GitHub CLI
     },
 } as const;
 
@@ -36,6 +42,16 @@ export function getDefaultEditor(): string {
 // Function to set the default editor
 export function setDefaultEditor(editor: string): void {
     config.set('defaultEditor', editor);
+}
+
+// Function to get the git provider
+export function getGitProvider(): 'gh' | 'glab' {
+    return config.get('gitProvider');
+}
+
+// Function to set the git provider
+export function setGitProvider(provider: 'gh' | 'glab'): void {
+    config.set('gitProvider', provider);
 }
 
 // Function to get the path to the config file (for debugging/info)

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,15 +154,26 @@ program
   .command("config")
   .description("Manage CLI configuration settings.")
   .addCommand(
-    new Command("set").description("Set a configuration value.").addCommand(
-      new Command("editor")
-        .argument(
-          "<editorName>",
-          "Name of the editor command (e.g., code, cursor, webstorm)"
-        )
-        .description("Set the default editor to open worktrees in.")
-        .action((editorName) => configHandler("set", "editor", editorName))
-    )
+    new Command("set")
+      .description("Set a configuration value.")
+      .addCommand(
+        new Command("editor")
+          .argument(
+            "<editorName>",
+            "Name of the editor command (e.g., code, cursor, webstorm)"
+          )
+          .description("Set the default editor to open worktrees in.")
+          .action((editorName) => configHandler("set", "editor", editorName))
+      )
+      .addCommand(
+        new Command("provider")
+          .argument(
+            "<providerName>",
+            "Git provider CLI to use (gh for GitHub, glab for GitLab)"
+          )
+          .description("Set the default git provider (gh or glab).")
+          .action((providerName) => configHandler("set", "provider", providerName))
+      )
   )
   .addCommand(
     new Command("get")
@@ -171,6 +182,11 @@ program
         new Command("editor")
           .description("Get the currently configured default editor.")
           .action(() => configHandler("get", "editor"))
+      )
+      .addCommand(
+        new Command("provider")
+          .description("Get the currently configured git provider.")
+          .action(() => configHandler("get", "provider"))
       )
   )
   .addCommand(

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -76,3 +76,21 @@ export async function getRepoRoot(cwd: string = "."): Promise<string | null> {
         return null;
     }
 }
+
+export async function detectGitProvider(cwd: string = "."): Promise<'gh' | 'glab' | null> {
+    try {
+        const { stdout } = await execa("git", ["-C", cwd, "remote", "get-url", "origin"]);
+        const remoteUrl = stdout.trim();
+
+        if (remoteUrl.includes('github.com')) {
+            return 'gh';
+        } else if (remoteUrl.includes('gitlab.com') || remoteUrl.includes('gitlab')) {
+            return 'glab';
+        }
+
+        return null;
+    } catch (error) {
+        console.error(chalk.yellow("Could not detect git provider from remote."), error);
+        return null;
+    }
+}


### PR DESCRIPTION
Add support for GitLab CLI (glab) alongside GitHub CLI (gh) for the pr command.

- Auto-detect git provider from remote URL (github.com or gitlab.com)
- Add config option: wt config set provider gh|glab
- Adapt pr command to work with both GitHub PRs and GitLab MRs
- Update error messages to be provider-specific (PR vs MR, GitHub vs GitLab)
- Add comprehensive documentation in README

The tool automatically detects the provider from the remote URL. Manual configuration is available as fallback via config command.

Backward compatible: defaults to gh (GitHub CLI) maintaining existing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-provider support for both GitHub and GitLab workflows
  * Configurable Git provider setting with automatic detection from repository URL
  * New commands: setup, open, and extract for enhanced workflow management

* **Bug Fixes**
  * Safety checks prevent operations on bare repositories
  * Improved error messaging for better user guidance

* **Documentation**
  * Updated documentation with PR and Merge Request terminology

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->