### PR TITLE
Fix prNumber argument to be optional as described in Readme

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -58,7 +58,7 @@ program
     .action(purgeWorktreesHandler);
 program
     .command("pr")
-    .argument("<prNumber>", "GitHub PR or GitLab MR number to create a worktree from")
+    .argument("[prNumber]", "GitHub PR or GitLab MR number to create a worktree from")
     .option("-p, --path <path>", "Specify a custom path for the worktree (defaults to repoName-branchName)")
     .option("-i, --install <packageManager>", "Package manager to use for installing dependencies (npm, pnpm, bun, etc.)")
     .option("-e, --editor <editor>", "Editor to use for opening the worktree (overrides default editor)")

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ program
 program
   .command("pr")
   .argument(
-    "<prNumber>",
+    "[prNumber]",
     "GitHub PR or GitLab MR number to create a worktree from"
   )
   .option(


### PR DESCRIPTION
`prNumber` is described as optional argument to subcommand `pr` in the Readme

currently it is a required argument, with this fix it will be a optional argument 

without `prNumber` this will then start the interactive flow

test run:

```
❯ pnpm test

> @johnlindquist/worktree@0.0.0-development test /home/mwyrsch/git/worktree-cli
> vitest run


 RUN  v3.1.1 /home/mwyrsch/git/worktree-cli

stdout | test/utils.test.ts > Atomic Operations > should track rollback actions in order

Rolling back changes...

stdout | test/utils.test.ts > Atomic Operations > should track rollback actions in order
Rollback complete.

stdout | test/utils.test.ts > Atomic Operations > should not rollback after commit
Operation already committed, skipping rollback.

 ✓ test/utils.test.ts (14 tests) 19ms
 ✓ test/git-utils.test.ts (14 tests) 381ms
 ✓ test/integration.test.ts (12 tests) 2806ms
   ✓ wt remove > should remove an existing worktree by path  331ms
   ✓ Branch Name Validation > should reject invalid branch names  361ms
   ✓ WorktreeInfo Parsing > should correctly parse worktree list output  462ms
   ✓ WorktreeInfo Parsing > should handle locked worktrees  311ms

 Test Files  3 passed (3)
      Tests  40 passed (40)
   Start at  17:27:49
   Duration  3.11s (transform 123ms, setup 0ms, collect 310ms, tests 3.21s, environment 0ms, prepare 232ms)
   
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `pr` command argument is now optional, allowing users to invoke the command without explicitly providing a PR/MR number.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->