### PR TITLE
feat: add automatic cleanup scripts on worktree removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,39 @@ wt remove [pathOrBranch] [options]
 
 **Interactive Selection**: Run `wt remove` without arguments to select a worktree to remove.
 
+**Cleanup Scripts**: If `cleanup-worktree` is defined in `worktrees.json`, those commands will be executed before removal (with user confirmation).
+
 Options:
 - `-f, --force`: Force removal without confirmation
+- `-s, --skip-cleanup`: Skip cleanup scripts defined in worktrees.json
+- `-t, --trust`: Trust and run cleanup commands without confirmation (for CI environments)
 
 Example:
 ```bash
-wt remove                    # Interactive selection
-wt remove feature/login      # Remove by branch name
-wt remove ./path/to/worktree # Remove by path
-wt remove feature/old -f     # Force remove
+wt remove                        # Interactive selection
+wt remove feature/login          # Remove by branch name
+wt remove ./path/to/worktree     # Remove by path
+wt remove feature/old -f         # Force remove
+wt remove feature/old -s         # Skip cleanup scripts
+wt remove feature/old -t         # Run cleanup without confirmation
 ```
+
+### Cleanup Worktree Configuration
+
+You can define cleanup commands that run automatically when removing a worktree:
+
+```json
+{
+  "setup-worktree": ["npm install"],
+  "cleanup-worktree": ["docker-compose down", "echo 'Cleanup complete'"]
+}
+```
+
+Cleanup behavior:
+- **Automatic execution**: Runs before `wt remove` (after confirmation)
+- **Skip option**: Use `--skip-cleanup` or `-s` to bypass
+- **Trust mode**: Use `--trust` to run without confirmation (CI environments)
+- **Environment variables**: `$ROOT_WORKTREE_PATH` is available
 
 ### Purge multiple worktrees
 

--- a/build/commands/remove.js
+++ b/build/commands/remove.js
@@ -4,6 +4,7 @@ import { stat, rm } from "node:fs/promises";
 import { findWorktreeByBranch, findWorktreeByPath } from "../utils/git.js";
 import { selectWorktree, confirm } from "../utils/tui.js";
 import { withSpinner } from "../utils/spinner.js";
+import { runCleanupScriptsSecure } from "../utils/setup.js";
 export async function removeWorktreeHandler(pathOrBranch = "", options) {
     try {
         await execa("git", ["rev-parse", "--is-inside-work-tree"]);
@@ -69,6 +70,10 @@ export async function removeWorktreeHandler(pathOrBranch = "", options) {
                 console.log(chalk.yellow("Removal cancelled."));
                 process.exit(0);
             }
+        }
+        // Execute cleanup scripts if not skipped
+        if (!options.skipCleanup) {
+            await runCleanupScriptsSecure(targetPath, { trust: options.trust });
         }
         // Remove the worktree
         try {

--- a/build/index.js
+++ b/build/index.js
@@ -44,7 +44,9 @@ program
     .alias("rm")
     .argument("[pathOrBranch]", "Path of the worktree or branch to remove.")
     .option("-f, --force", "Force removal of worktree and deletion of the folder", false)
-    .description("Remove a specified worktree. Cleans up the .git/worktrees references.")
+    .option("-s, --skip-cleanup", "Skip cleanup scripts defined in worktrees.json", false)
+    .option("-t, --trust", "Trust and run cleanup commands without confirmation (for CI environments)", false)
+    .description("Remove a specified worktree. Runs cleanup-worktree scripts from worktrees.json before removal.")
     .action(removeWorktreeHandler);
 program
     .command("merge")

--- a/build/utils/setup.js
+++ b/build/utils/setup.js
@@ -195,3 +195,78 @@ export async function runSetupScripts(worktreePath) {
         return false;
     }
 }
+/**
+ * Load and parse cleanup commands from worktrees.json
+ */
+async function loadCleanupCommands(repoRoot) {
+    const paths = [
+        join(repoRoot, ".cursor", "worktrees.json"),
+        join(repoRoot, "worktrees.json"),
+    ];
+    for (const configPath of paths) {
+        try {
+            await stat(configPath);
+            const content = await readFile(configPath, "utf-8");
+            const data = JSON.parse(content);
+            if (data && typeof data === 'object' && !Array.isArray(data) && Array.isArray(data["cleanup-worktree"])) {
+                const commands = data["cleanup-worktree"];
+                if (commands.length > 0) {
+                    return { commands, filePath: configPath };
+                }
+            }
+        }
+        catch {
+            // Not found, try next
+        }
+    }
+    return null;
+}
+/**
+ * Execute cleanup commands before worktree removal (SECURE)
+ *
+ * This function loads cleanup-worktree commands from worktrees.json and executes them
+ * with user confirmation (unless --trust flag is set).
+ *
+ * @param worktreePath - Path to the worktree where commands should be executed
+ * @param options - Execution options (trust flag bypasses confirmation)
+ * @returns true if cleanup commands were found and executed, false if no cleanup commands exist
+ */
+export async function runCleanupScriptsSecure(worktreePath, options = {}) {
+    const repoRoot = await getRepoRoot();
+    if (!repoRoot) {
+        return false;
+    }
+    const cleanupResult = await loadCleanupCommands(repoRoot);
+    if (!cleanupResult) {
+        return false;
+    }
+    console.log(chalk.blue(`Found cleanup config: ${cleanupResult.filePath}`));
+    // Show commands and ask for confirmation (unless --trust flag is set)
+    const shouldRun = await confirmCommands(cleanupResult.commands, {
+        title: "The following cleanup commands will be executed:",
+        trust: options.trust,
+    });
+    if (!shouldRun) {
+        console.log(chalk.yellow("Cleanup commands skipped."));
+        return false;
+    }
+    // Execute commands
+    const env = { ...process.env, ROOT_WORKTREE_PATH: repoRoot };
+    for (const command of cleanupResult.commands) {
+        console.log(chalk.gray(`Executing: ${command}`));
+        try {
+            await execa(command, { shell: true, cwd: worktreePath, env, stdio: "inherit" });
+        }
+        catch (cmdError) {
+            if (cmdError instanceof Error) {
+                console.error(chalk.red(`Cleanup command failed: ${command}`), cmdError.message);
+            }
+            else {
+                console.error(chalk.red(`Cleanup command failed: ${command}`), cmdError);
+            }
+            // Continue with other commands
+        }
+    }
+    console.log(chalk.green("Cleanup commands completed."));
+    return true;
+}

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -5,10 +5,11 @@ import { resolve } from "node:path";
 import { getWorktrees, findWorktreeByBranch, findWorktreeByPath, WorktreeInfo } from "../utils/git.js";
 import { selectWorktree, confirm } from "../utils/tui.js";
 import { withSpinner } from "../utils/spinner.js";
+import { runCleanupScriptsSecure } from "../utils/setup.js";
 
 export async function removeWorktreeHandler(
     pathOrBranch: string = "",
-    options: { force?: boolean }
+    options: { force?: boolean; skipCleanup?: boolean; trust?: boolean }
 ) {
     try {
         await execa("git", ["rev-parse", "--is-inside-work-tree"]);
@@ -83,6 +84,11 @@ export async function removeWorktreeHandler(
                 console.log(chalk.yellow("Removal cancelled."));
                 process.exit(0);
             }
+        }
+
+        // Execute cleanup scripts if not skipped
+        if (!options.skipCleanup) {
+            await runCleanupScriptsSecure(targetPath, { trust: options.trust });
         }
 
         // Remove the worktree

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,8 +84,18 @@ program
     "Force removal of worktree and deletion of the folder",
     false
   )
+  .option(
+    "-s, --skip-cleanup",
+    "Skip cleanup scripts defined in worktrees.json",
+    false
+  )
+  .option(
+    "-t, --trust",
+    "Trust and run cleanup commands without confirmation (for CI environments)",
+    false
+  )
   .description(
-    "Remove a specified worktree. Cleans up the .git/worktrees references."
+    "Remove a specified worktree. Runs cleanup-worktree scripts from worktrees.json before removal."
   )
   .action(removeWorktreeHandler);
 

--- a/src/utils/setup.ts
+++ b/src/utils/setup.ts
@@ -9,6 +9,7 @@ import { confirmCommands } from "./tui.js";
 
 interface WorktreeSetupData {
     "setup-worktree"?: string[];
+    "cleanup-worktree"?: string[];
     [key: string]: unknown;
 }
 
@@ -211,4 +212,90 @@ export async function runSetupScripts(worktreePath: string): Promise<boolean> {
         }
         return false;
     }
+}
+
+/**
+ * Load and parse cleanup commands from worktrees.json
+ */
+async function loadCleanupCommands(repoRoot: string): Promise<{ commands: string[]; filePath: string } | null> {
+    const paths = [
+        join(repoRoot, ".cursor", "worktrees.json"),
+        join(repoRoot, "worktrees.json"),
+    ];
+
+    for (const configPath of paths) {
+        try {
+            await stat(configPath);
+            const content = await readFile(configPath, "utf-8");
+            const data = JSON.parse(content) as WorktreeSetupData;
+
+            if (data && typeof data === 'object' && !Array.isArray(data) && Array.isArray(data["cleanup-worktree"])) {
+                const commands = data["cleanup-worktree"];
+                if (commands.length > 0) {
+                    return { commands, filePath: configPath };
+                }
+            }
+        } catch {
+            // Not found, try next
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Execute cleanup commands before worktree removal (SECURE)
+ *
+ * This function loads cleanup-worktree commands from worktrees.json and executes them
+ * with user confirmation (unless --trust flag is set).
+ *
+ * @param worktreePath - Path to the worktree where commands should be executed
+ * @param options - Execution options (trust flag bypasses confirmation)
+ * @returns true if cleanup commands were found and executed, false if no cleanup commands exist
+ */
+export async function runCleanupScriptsSecure(
+    worktreePath: string,
+    options: { trust?: boolean } = {}
+): Promise<boolean> {
+    const repoRoot = await getRepoRoot();
+    if (!repoRoot) {
+        return false;
+    }
+
+    const cleanupResult = await loadCleanupCommands(repoRoot);
+
+    if (!cleanupResult) {
+        return false;
+    }
+
+    console.log(chalk.blue(`Found cleanup config: ${cleanupResult.filePath}`));
+
+    // Show commands and ask for confirmation (unless --trust flag is set)
+    const shouldRun = await confirmCommands(cleanupResult.commands, {
+        title: "The following cleanup commands will be executed:",
+        trust: options.trust,
+    });
+
+    if (!shouldRun) {
+        console.log(chalk.yellow("Cleanup commands skipped."));
+        return false;
+    }
+
+    // Execute commands
+    const env = { ...process.env, ROOT_WORKTREE_PATH: repoRoot };
+    for (const command of cleanupResult.commands) {
+        console.log(chalk.gray(`Executing: ${command}`));
+        try {
+            await execa(command, { shell: true, cwd: worktreePath, env, stdio: "inherit" });
+        } catch (cmdError: unknown) {
+            if (cmdError instanceof Error) {
+                console.error(chalk.red(`Cleanup command failed: ${command}`), cmdError.message);
+            } else {
+                console.error(chalk.red(`Cleanup command failed: ${command}`), cmdError);
+            }
+            // Continue with other commands
+        }
+    }
+    console.log(chalk.green("Cleanup commands completed."));
+    return true;
 }


### PR DESCRIPTION
Add support for `cleanup-worktree` scripts that run automatically when removing a worktree with `wt remove`.

## Summary
- Add `cleanup-worktree` array support in `worktrees.json` for automatic cleanup before worktree removal
- Scripts execute automatically when using `wt remove`
- Add `--skip-cleanup` (`-s`) option to bypass cleanup scripts
- Add `--trust` (`-t`) option for CI environments (no confirmation)
- Add `runCleanupScriptsSecure()` function to src/utils/setup.ts
- Extract shared script execution logic to `src/utils/scripts.ts` (removes code duplication from setup.ts)
- Use same security filters as `setup-worktree` (dangerous commands blocked)
- Update `README` with cleanup documentation

## Example worktrees.json
```json
{
  "setup-worktree": ["npm install"],
  "cleanup-worktree": ["docker-compose down", "rm -rf node_modules"]
}
```

# Usage

wt remove my-branch           # Runs cleanup scripts, then removes worktree
wt remove my-branch -s        # Skips cleanup scripts
wt remove my-branch --force   # Force removal (for untracked files)

# Test plan

[x] `wt setup` still executes `setup-worktree` scripts correctly
[x] `wt remove` executes `cleanup-worktree` scripts before removal
[x] `wt remove --skip-cleanup` bypasses cleanup scripts
[x] `wt remove --force` works with untracked files
[x] Security filters block dangerous commands in cleanup scripts
[x] `pnpm build` compiles without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cleanup-worktree scripts support: Define cleanup commands in worktrees.json to execute before removing a worktree.
  * New CLI options for `remove` command:
    * `-s, --skip-cleanup`: Skip cleanup script execution.
    * `-t, --trust`: Run cleanup without user confirmation (ideal for CI/CD environments).
  * Cleanup scripts run with user confirmation by default before worktree removal.

* **Documentation**
  * Updated README with cleanup configuration examples and new CLI option details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->