### PR TITLE
feat: Add `wt cd` command and `wt init` for native shell integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,52 @@ wt open [pathOrBranch]
 
 **Interactive Selection**: Run `wt open` without arguments to see a fuzzy-searchable list of worktrees.
 
+Options:
+- `-e, --editor <editor>`: Editor to use for opening the worktree (overrides default editor)
+
+When the editor is set to `none` (via `wt config set editor none` or `-e none`), `wt open` prints **only the worktree path** to stdout (all UI/error output remains on stderr) instead of launching an editor. Note that this differs from `wt cd`, which opens a subshell in the worktree directory.
+
 Example:
 ```bash
 wt open                    # Interactive selection
 wt open feature/login      # Open by branch name
 wt open ./path/to/worktree # Open by path
 ```
+
+### CD into a worktree
+
+```bash
+wt cd [pathOrBranch]
+```
+
+Opens a new shell session inside the selected worktree directory. Type `exit` to return to your previous directory (on Unix, `Ctrl+D` also works; on Windows `cmd.exe`, use `Ctrl+Z` then Enter).
+
+Options:
+- `--print`: Print the resolved path to stdout instead of spawning a subshell
+
+Example:
+```bash
+wt cd                     # Interactive selection, opens shell in worktree
+wt cd feature/login       # Open shell in branch's worktree
+wt cd feature/login --print  # Print path only (for scripting)
+```
+
+### Shell Integration
+
+For native `cd` support (changes your current shell directory instead of spawning a subshell):
+
+```bash
+# Auto-detect shell and show setup instructions:
+wt init
+
+# Or specify explicitly — add to your .zshrc or .bashrc:
+eval "$(wt init zsh)"    # or bash
+
+# For fish, add to config.fish:
+wt init fish | source
+```
+
+After setup, `wt cd` will change your current shell's directory directly via a shell wrapper function.
 
 ### List worktrees
 

--- a/build/commands/cd.js
+++ b/build/commands/cd.js
@@ -1,23 +1,26 @@
 import { execa } from "execa";
 import chalk from "chalk";
 import { stat } from "node:fs/promises";
+import { constants } from "node:os";
 import { resolve } from "node:path";
-import { getDefaultEditor, shouldSkipEditor } from "../config.js";
 import { findWorktreeByBranch, findWorktreeByPath } from "../utils/git.js";
 import { selectWorktree } from "../utils/tui.js";
 function isEnoent(err) {
     return err instanceof Error && 'code' in err && err.code === 'ENOENT';
 }
-export async function openWorktreeHandler(pathOrBranch = "", options) {
+export async function cdWorktreeHandler(pathOrBranch = "", options = {}) {
     try {
-        // 1. Validate we're in a git repo
-        await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        const gitCheck = await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        if (gitCheck.exitCode !== 0 || gitCheck.stdout.trim() !== "true") {
+            process.stderr.write(chalk.red("Not inside a git work tree.") + "\n");
+            process.exit(1);
+        }
         let targetWorktree = null;
-        // Improvement #4: Interactive TUI for missing arguments
         if (!pathOrBranch) {
             const selected = await selectWorktree({
-                message: "Select a worktree to open",
+                message: "Select a worktree to cd into",
                 excludeMain: false,
+                ...(options.print ? { stdout: process.stderr } : {}),
             });
             if (!selected || Array.isArray(selected)) {
                 process.stderr.write(chalk.yellow("No worktree selected.") + "\n");
@@ -26,7 +29,7 @@ export async function openWorktreeHandler(pathOrBranch = "", options) {
             targetWorktree = selected;
         }
         else {
-            // Try to find by path first
+            // Check if argument is an existing filesystem path
             let pathStats = null;
             try {
                 pathStats = await stat(pathOrBranch);
@@ -64,18 +67,16 @@ export async function openWorktreeHandler(pathOrBranch = "", options) {
                     process.exit(1);
                 }
             }
-            // If not found by path, try by branch name
             if (!targetWorktree) {
                 targetWorktree = await findWorktreeByBranch(pathOrBranch);
                 if (!targetWorktree) {
                     process.stderr.write(chalk.red(`Could not find a worktree for branch "${pathOrBranch}".`) + "\n");
-                    process.stderr.write(chalk.yellow("Use 'wt list' to see existing worktrees, or run 'wt open' without arguments to select interactively.") + "\n");
+                    process.stderr.write(chalk.yellow("Use 'wt list' to see existing worktrees, or run 'wt cd' without arguments to select interactively.") + "\n");
                     process.exit(1);
                 }
             }
         }
         const targetPath = targetWorktree.path;
-        // Verify the target path exists
         try {
             await stat(targetPath);
         }
@@ -86,44 +87,32 @@ export async function openWorktreeHandler(pathOrBranch = "", options) {
             process.stderr.write(chalk.yellow("The worktree may have been removed. Run 'git worktree prune' to clean up.") + "\n");
             process.exit(1);
         }
-        // Open in the specified editor (or use configured default)
-        const configuredEditor = getDefaultEditor();
-        const editorCommand = options.editor || configuredEditor;
-        if (shouldSkipEditor(editorCommand)) {
+        if (options.print) {
             process.stdout.write(targetPath + "\n");
+            return;
         }
-        else {
-            // Display worktree info
-            if (targetWorktree.branch) {
-                console.log(chalk.blue(`Opening worktree for branch "${targetWorktree.branch}"...`));
-            }
-            else if (targetWorktree.detached) {
-                console.log(chalk.blue(`Opening detached worktree at ${targetWorktree.head.substring(0, 7)}...`));
-            }
-            else {
-                console.log(chalk.blue(`Opening worktree at ${targetPath}...`));
-            }
-            // Show status indicators
-            if (targetWorktree.locked) {
-                console.log(chalk.yellow(`Note: This worktree is locked${targetWorktree.lockReason ? `: ${targetWorktree.lockReason}` : ''}`));
-            }
-            if (targetWorktree.prunable) {
-                console.log(chalk.yellow(`Warning: This worktree is marked as prunable${targetWorktree.pruneReason ? `: ${targetWorktree.pruneReason}` : ''}`));
-            }
-            console.log(chalk.blue(`Opening ${targetPath} in ${editorCommand}...`));
-            try {
-                await execa(editorCommand, [targetPath], { stdio: "inherit" });
-                console.log(chalk.green(`Successfully opened worktree in ${editorCommand}.`));
-            }
-            catch (editorError) {
-                process.stderr.write(chalk.red(`Failed to open editor "${editorCommand}". Please ensure it's installed and in your PATH.`) + "\n");
-                process.exit(1);
-            }
+        // Spawn a subshell in the target directory so cd works without shell config
+        const shell = process.platform === "win32"
+            ? process.env.COMSPEC || "cmd.exe"
+            : process.env.SHELL || "/bin/sh";
+        process.stderr.write(chalk.green(`Entering ${targetPath}`) + "\n");
+        process.stderr.write(chalk.dim(`(exit or ctrl+d to return)`) + "\n");
+        const result = await execa(shell, [], {
+            cwd: targetPath,
+            stdio: "inherit",
+            reject: false,
+        });
+        if (result.signal) {
+            const signum = constants.signals[result.signal] ?? 0;
+            process.exit(128 + signum);
+        }
+        if (result.exitCode != null && result.exitCode !== 0) {
+            process.exit(result.exitCode);
         }
     }
     catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        process.stderr.write(chalk.red("Failed to open worktree: ") + message + "\n");
+        process.stderr.write(chalk.red("Failed to resolve worktree: ") + message + "\n");
         process.exit(1);
     }
 }

--- a/build/commands/init.js
+++ b/build/commands/init.js
@@ -1,0 +1,104 @@
+import chalk from "chalk";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+// Shell wrapper functions that intercept `wt cd` to perform a native directory
+// change via `--print`. If `--print` exits non-zero (e.g. no worktree found),
+// falls back to the normal subshell-based `wt cd`.
+const BASH_ZSH_FUNCTION = `wt() {
+  if [[ "\$1" == "cd" ]]; then
+    shift
+    local dir
+    dir=$(command wt cd --print "\$@")
+    if [[ \$? -eq 0 && -n "\$dir" ]]; then
+      builtin cd "\$dir"
+    else
+      command wt cd "\$@"
+    fi
+  else
+    command wt "\$@"
+  fi
+}`;
+const FISH_FUNCTION = `function wt
+  if test (count $argv) -gt 0 -a "$argv[1]" = "cd"
+    set -l dir (command wt cd --print $argv[2..-1])
+    if test $status -eq 0 -a -n "$dir"
+      builtin cd $dir
+    else
+      command wt cd $argv[2..-1]
+    end
+  else
+    command wt $argv
+  end
+end`;
+const SUPPORTED_SHELLS = ["zsh", "bash", "fish"];
+const SHELL_RC = {
+    zsh: { file: "~/.zshrc", line: 'eval "$(wt init zsh)"' },
+    bash: { file: "~/.bashrc", line: 'eval "$(wt init bash)"' },
+    fish: { file: "~/.config/fish/config.fish", line: "wt init fish | source" },
+};
+export function getShellFunction(shell) {
+    if (shell === "fish")
+        return FISH_FUNCTION;
+    return BASH_ZSH_FUNCTION;
+}
+export function detectShell() {
+    const shellEnv = process.env.SHELL || "";
+    const basename = shellEnv.split("/").pop()?.toLowerCase() || "";
+    if (SUPPORTED_SHELLS.includes(basename))
+        return basename;
+    return null;
+}
+function expandTilde(path) {
+    return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
+}
+function isAlreadyInstalled(rc) {
+    try {
+        const content = readFileSync(expandTilde(rc.file), "utf-8");
+        return content.includes(rc.line);
+    }
+    catch {
+        return false;
+    }
+}
+const SHELL_SOURCE = {
+    zsh: "source ~/.zshrc",
+    bash: "source ~/.bashrc",
+    fish: "source ~/.config/fish/config.fish",
+};
+export function initHandler(shell) {
+    let resolved;
+    if (shell) {
+        const normalized = shell.toLowerCase();
+        if (!SUPPORTED_SHELLS.includes(normalized)) {
+            process.stderr.write(chalk.red(`Unsupported shell: "${shell}". Supported shells: ${SUPPORTED_SHELLS.join(", ")}`) + "\n");
+            process.exit(1);
+        }
+        resolved = normalized;
+    }
+    else {
+        const detected = detectShell();
+        if (!detected) {
+            process.stderr.write(chalk.red("Could not detect shell from $SHELL.") + "\n");
+            process.stderr.write(chalk.yellow(`Usage: wt init <${SUPPORTED_SHELLS.join("|")}>`) + "\n");
+            process.exit(1);
+        }
+        resolved = detected;
+        process.stderr.write(chalk.dim(`Detected shell: ${resolved}`) + "\n");
+    }
+    process.stdout.write(getShellFunction(resolved) + "\n");
+    const rc = SHELL_RC[resolved];
+    if (isAlreadyInstalled(rc)) {
+        process.stderr.write(chalk.green(`Already installed in ${rc.file}`) + "\n");
+        return;
+    }
+    process.stderr.write(chalk.dim(`# Add to ${rc.file}:`) + "\n");
+    process.stderr.write(chalk.dim("#   " + rc.line) + "\n");
+    process.stderr.write("\n");
+    process.stderr.write(chalk.dim("# Run this to add it automatically:") + "\n");
+    const appendCmd = `echo '${rc.line}' >> ${rc.file}`;
+    process.stderr.write("  " + chalk.cyan(appendCmd) + "\n");
+    process.stderr.write("\n");
+    process.stderr.write(chalk.dim("# Then reload your shell:") + "\n");
+    process.stderr.write("  " + chalk.cyan(SHELL_SOURCE[resolved]) + "\n");
+}

--- a/build/commands/init.js
+++ b/build/commands/init.js
@@ -87,6 +87,10 @@ export function initHandler(shell) {
         process.stderr.write(chalk.dim(`Detected shell: ${resolved}`) + "\n");
     }
     process.stdout.write(getShellFunction(resolved) + "\n");
+    // When called with an explicit shell arg (e.g. `eval "$(wt init zsh)"`),
+    // the user just wants the shell function emitted to stdout — no guidance.
+    if (shell)
+        return;
     const rc = SHELL_RC[resolved];
     if (isAlreadyInstalled(rc)) {
         process.stderr.write(chalk.green(`Already installed in ${rc.file}`) + "\n");

--- a/build/commands/open.js
+++ b/build/commands/open.js
@@ -11,7 +11,11 @@ function isEnoent(err) {
 export async function openWorktreeHandler(pathOrBranch = "", options) {
     try {
         // 1. Validate we're in a git repo
-        await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        const { exitCode } = await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        if (exitCode !== 0) {
+            process.stderr.write(chalk.red("Not inside a git repository.") + "\n");
+            process.exit(1);
+        }
         let targetWorktree = null;
         // Improvement #4: Interactive TUI for missing arguments
         if (!pathOrBranch) {

--- a/build/commands/open.js
+++ b/build/commands/open.js
@@ -57,7 +57,9 @@ export async function openWorktreeHandler(pathOrBranch = "", options) {
                                 bare: false,
                             };
                         }
-                        catch {
+                        catch (gitErr) {
+                            if (!isEnoent(gitErr))
+                                throw gitErr;
                             process.stderr.write(chalk.red(`The path "${pathOrBranch}" exists but is not a git worktree.`) + "\n");
                             process.exit(1);
                         }

--- a/build/index.js
+++ b/build/index.js
@@ -10,6 +10,8 @@ import { configHandler } from "./commands/config.js";
 import { prWorktreeHandler } from "./commands/pr.js";
 import { openWorktreeHandler } from "./commands/open.js";
 import { extractWorktreeHandler } from "./commands/extract.js";
+import { cdWorktreeHandler } from "./commands/cd.js";
+import { initHandler } from "./commands/init.js";
 const program = new Command();
 program
     .name("wt")
@@ -75,6 +77,17 @@ program
     .option("-e, --editor <editor>", "Editor to use for opening the worktree (overrides default editor)")
     .description("Open an existing worktree in the editor.")
     .action(openWorktreeHandler);
+program
+    .command("cd")
+    .argument("[pathOrBranch]", "Path to worktree or branch name")
+    .option("--print", "Print the resolved path to stdout instead of spawning a subshell")
+    .description("Opens a subshell in the selected worktree directory.")
+    .action(cdWorktreeHandler);
+program
+    .command("init")
+    .argument("[shell]", "Shell to generate integration for (zsh, bash, fish)")
+    .description("Output shell integration function for native cd support.")
+    .action(initHandler);
 program
     .command("extract")
     .argument("[branchName]", "Name of the branch to extract (defaults to current branch)")

--- a/build/utils/tui.js
+++ b/build/utils/tui.js
@@ -12,7 +12,7 @@ import { getWorktrees } from "./git.js";
  * @returns Selected worktree(s) or null if cancelled
  */
 export async function selectWorktree(options) {
-    const { message = "Select a worktree", excludeMain = false, multiSelect = false } = options;
+    const { message = "Select a worktree", excludeMain = false, multiSelect = false, stdout } = options;
     const worktrees = await getWorktrees();
     if (worktrees.length === 0) {
         console.log(chalk.yellow("No worktrees found."));
@@ -38,6 +38,7 @@ export async function selectWorktree(options) {
             choices,
             hint: '- Space to select. Enter to confirm.',
             instructions: false,
+            ...(stdout ? { stdout } : {}),
         });
         if (!response.worktrees || response.worktrees.length === 0) {
             return null;
@@ -45,7 +46,7 @@ export async function selectWorktree(options) {
         return response.worktrees;
     }
     else {
-        const response = await prompts({
+        const promptOpts = {
             type: 'autocomplete',
             name: 'worktree',
             message,
@@ -54,7 +55,10 @@ export async function selectWorktree(options) {
                 const lowercaseInput = input.toLowerCase();
                 return Promise.resolve(choices.filter((choice) => choice.title.toLowerCase().includes(lowercaseInput)));
             },
-        });
+        };
+        if (stdout)
+            promptOpts.stdout = stdout;
+        const response = await prompts(promptOpts);
         return response.worktree;
     }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,122 @@
+import chalk from "chalk";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+
+// Shell wrapper functions that intercept `wt cd` to perform a native directory
+// change via `--print`. If `--print` exits non-zero (e.g. no worktree found),
+// falls back to the normal subshell-based `wt cd`.
+const BASH_ZSH_FUNCTION = `wt() {
+  if [[ "\$1" == "cd" ]]; then
+    shift
+    local dir
+    dir=$(command wt cd --print "\$@")
+    if [[ \$? -eq 0 && -n "\$dir" ]]; then
+      builtin cd "\$dir"
+    else
+      command wt cd "\$@"
+    fi
+  else
+    command wt "\$@"
+  fi
+}`;
+
+const FISH_FUNCTION = `function wt
+  if test (count $argv) -gt 0 -a "$argv[1]" = "cd"
+    set -l dir (command wt cd --print $argv[2..-1])
+    if test $status -eq 0 -a -n "$dir"
+      builtin cd $dir
+    else
+      command wt cd $argv[2..-1]
+    end
+  else
+    command wt $argv
+  end
+end`;
+
+const SUPPORTED_SHELLS = ["zsh", "bash", "fish"] as const;
+type Shell = (typeof SUPPORTED_SHELLS)[number];
+
+const SHELL_RC: Record<Shell, { file: string; line: string }> = {
+    zsh: { file: "~/.zshrc", line: 'eval "$(wt init zsh)"' },
+    bash: { file: "~/.bashrc", line: 'eval "$(wt init bash)"' },
+    fish: { file: "~/.config/fish/config.fish", line: "wt init fish | source" },
+};
+
+export function getShellFunction(shell: Shell): string {
+    if (shell === "fish") return FISH_FUNCTION;
+    return BASH_ZSH_FUNCTION;
+}
+
+export function detectShell(): Shell | null {
+    const shellEnv = process.env.SHELL || "";
+    const basename = shellEnv.split("/").pop()?.toLowerCase() || "";
+    if (SUPPORTED_SHELLS.includes(basename as Shell)) return basename as Shell;
+    return null;
+}
+
+function expandTilde(path: string): string {
+    return path.startsWith("~/") ? resolve(homedir(), path.slice(2)) : path;
+}
+
+function isAlreadyInstalled(rc: { file: string; line: string }): boolean {
+    try {
+        const content = readFileSync(expandTilde(rc.file), "utf-8");
+        return content.includes(rc.line);
+    } catch {
+        return false;
+    }
+}
+
+const SHELL_SOURCE: Record<Shell, string> = {
+    zsh: "source ~/.zshrc",
+    bash: "source ~/.bashrc",
+    fish: "source ~/.config/fish/config.fish",
+};
+
+export function initHandler(shell?: string): void {
+    let resolved: Shell;
+
+    if (shell) {
+        const normalized = shell.toLowerCase();
+        if (!SUPPORTED_SHELLS.includes(normalized as Shell)) {
+            process.stderr.write(
+                chalk.red(`Unsupported shell: "${shell}". Supported shells: ${SUPPORTED_SHELLS.join(", ")}`) + "\n"
+            );
+            process.exit(1);
+        }
+        resolved = normalized as Shell;
+    } else {
+        const detected = detectShell();
+        if (!detected) {
+            process.stderr.write(
+                chalk.red("Could not detect shell from $SHELL.") + "\n"
+            );
+            process.stderr.write(
+                chalk.yellow(`Usage: wt init <${SUPPORTED_SHELLS.join("|")}>`) + "\n"
+            );
+            process.exit(1);
+        }
+        resolved = detected;
+        process.stderr.write(chalk.dim(`Detected shell: ${resolved}`) + "\n");
+    }
+
+    process.stdout.write(getShellFunction(resolved) + "\n");
+
+    const rc = SHELL_RC[resolved];
+
+    if (isAlreadyInstalled(rc)) {
+        process.stderr.write(chalk.green(`Already installed in ${rc.file}`) + "\n");
+        return;
+    }
+
+    process.stderr.write(chalk.dim(`# Add to ${rc.file}:`) + "\n");
+    process.stderr.write(chalk.dim("#   " + rc.line) + "\n");
+    process.stderr.write("\n");
+    process.stderr.write(chalk.dim("# Run this to add it automatically:") + "\n");
+    const appendCmd = `echo '${rc.line}' >> ${rc.file}`;
+    process.stderr.write("  " + chalk.cyan(appendCmd) + "\n");
+    process.stderr.write("\n");
+    process.stderr.write(chalk.dim("# Then reload your shell:") + "\n");
+    process.stderr.write("  " + chalk.cyan(SHELL_SOURCE[resolved]) + "\n");
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,7 +12,7 @@ const BASH_ZSH_FUNCTION = `wt() {
     local dir
     dir=$(command wt cd --print "\$@")
     if [[ \$? -eq 0 && -n "\$dir" ]]; then
-      builtin cd "\$dir"
+      builtin cd -- "\$dir"
     else
       command wt cd "\$@"
     fi

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -25,7 +25,7 @@ const FISH_FUNCTION = `function wt
   if test (count $argv) -gt 0 -a "$argv[1]" = "cd"
     set -l dir (command wt cd --print $argv[2..-1])
     if test $status -eq 0 -a -n "$dir"
-      builtin cd $dir
+      builtin cd -- "$dir"
     else
       command wt cd $argv[2..-1]
     end

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -103,6 +103,10 @@ export function initHandler(shell?: string): void {
 
     process.stdout.write(getShellFunction(resolved) + "\n");
 
+    // When called with an explicit shell arg (e.g. `eval "$(wt init zsh)"`),
+    // the user just wants the shell function emitted to stdout — no guidance.
+    if (shell) return;
+
     const rc = SHELL_RC[resolved];
 
     if (isAlreadyInstalled(rc)) {

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -16,7 +16,11 @@ export async function openWorktreeHandler(
 ) {
     try {
         // 1. Validate we're in a git repo
-        await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        const { exitCode } = await execa("git", ["rev-parse", "--is-inside-work-tree"], { reject: false });
+        if (exitCode !== 0) {
+            process.stderr.write(chalk.red("Not inside a git repository.") + "\n");
+            process.exit(1);
+        }
 
         let targetWorktree: WorktreeInfo | null = null;
 

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -63,7 +63,8 @@ export async function openWorktreeHandler(
                                 isMain: false,
                                 bare: false,
                             };
-                        } catch {
+                        } catch (gitErr: unknown) {
+                            if (!isEnoent(gitErr)) throw gitErr;
                             process.stderr.write(chalk.red(`The path "${pathOrBranch}" exists but is not a git worktree.`) + "\n");
                             process.exit(1);
                         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import { configHandler } from "./commands/config.js";
 import { prWorktreeHandler } from "./commands/pr.js";
 import { openWorktreeHandler } from "./commands/open.js";
 import { extractWorktreeHandler } from "./commands/extract.js";
+import { cdWorktreeHandler } from "./commands/cd.js";
+import { initHandler } from "./commands/init.js";
 
 const program = new Command();
 
@@ -148,6 +150,19 @@ program
   )
   .description("Open an existing worktree in the editor.")
   .action(openWorktreeHandler);
+
+program
+  .command("cd")
+  .argument("[pathOrBranch]", "Path to worktree or branch name")
+  .option("--print", "Print the resolved path to stdout instead of spawning a subshell")
+  .description("Opens a subshell in the selected worktree directory.")
+  .action(cdWorktreeHandler);
+
+program
+  .command("init")
+  .argument("[shell]", "Shell to generate integration for (zsh, bash, fish)")
+  .description("Output shell integration function for native cd support.")
+  .action(initHandler);
 
 program
   .command("extract")

--- a/test/cd.test.ts
+++ b/test/cd.test.ts
@@ -1,0 +1,440 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { WorktreeInfo } from '../src/utils/git.js';
+
+/**
+ * Unit tests for the `wt cd` command handler.
+ *
+ * These mock all dependencies (git utils, TUI, fs, execa) to test
+ * the handler's branching logic, subshell spawning, stderr routing,
+ * and exit codes in isolation.
+ */
+
+const mockWorktrees: WorktreeInfo[] = [
+    {
+        path: '/fake/repo',
+        head: 'aaa111',
+        branch: 'main',
+        detached: false,
+        locked: false,
+        prunable: false,
+        isMain: true,
+        bare: false,
+    },
+    {
+        path: '/fake/worktrees/feature-login',
+        head: 'bbb222',
+        branch: 'feature/login',
+        detached: false,
+        locked: false,
+        prunable: false,
+        isMain: false,
+        bare: false,
+    },
+    {
+        path: '/fake/worktrees/detached-wt',
+        head: 'ccc333',
+        branch: null,
+        detached: true,
+        locked: false,
+        prunable: false,
+        isMain: false,
+        bare: false,
+    },
+];
+
+// --- Mocks ---
+
+const mockExeca = vi.fn(async () => ({ stdout: 'true', exitCode: 0 }));
+vi.mock('execa', () => ({ execa: mockExeca }));
+
+const mockFindByBranch = vi.fn(async () => null as WorktreeInfo | null);
+const mockFindByPath = vi.fn(async () => null as WorktreeInfo | null);
+vi.mock('../src/utils/git.js', () => ({
+    findWorktreeByBranch: mockFindByBranch,
+    findWorktreeByPath: mockFindByPath,
+    getWorktrees: vi.fn(async () => mockWorktrees),
+}));
+
+const mockSelectWorktree = vi.fn(async () => null as WorktreeInfo | WorktreeInfo[] | null);
+vi.mock('../src/utils/tui.js', () => ({
+    selectWorktree: mockSelectWorktree,
+}));
+
+function enoentError(): Error {
+    const err = new Error('ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    return err;
+}
+
+const mockStat = vi.fn(async () => { throw enoentError(); });
+vi.mock('node:fs/promises', () => ({
+    stat: mockStat,
+}));
+
+describe('cdWorktreeHandler', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    const originalShell = process.env.SHELL;
+
+    beforeEach(() => {
+        stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit');
+        }) as any);
+
+        process.env.SHELL = '/bin/zsh';
+
+        // Reset all mocks to defaults
+        mockExeca.mockReset().mockResolvedValue({ stdout: 'true', exitCode: 0 } as any);
+        mockFindByBranch.mockReset().mockResolvedValue(null);
+        mockFindByPath.mockReset().mockResolvedValue(null);
+        mockSelectWorktree.mockReset().mockResolvedValue(null);
+        mockStat.mockReset().mockRejectedValue(enoentError());
+    });
+
+    afterEach(() => {
+        stdoutSpy.mockRestore();
+        stderrSpy.mockRestore();
+        exitSpy.mockRestore();
+        process.env.SHELL = originalShell;
+    });
+
+    // --- Branch name resolution ---
+
+    it('should spawn subshell in worktree dir when branch is found', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // stat for input: not a path (throws)
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[1]);
+        // stat for target path verification: exists
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('feature/login');
+
+        expect(mockExeca).toHaveBeenCalledWith('/bin/zsh', [], {
+            cwd: '/fake/worktrees/feature-login',
+            stdio: 'inherit',
+            reject: false,
+        });
+        expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not write anything to stdout on branch not found', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockFindByBranch.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('no-such-branch')).rejects.toThrow('process.exit');
+
+        expect(stdoutSpy).not.toHaveBeenCalled();
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should write error to stderr when branch not found', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockFindByBranch.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('missing')).rejects.toThrow('process.exit');
+
+        expect(stderrSpy).toHaveBeenCalled();
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Could not find a worktree');
+        expect(stderrOutput).toContain('missing');
+    });
+
+    it('should suggest wt list and wt cd in error for missing branch', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockFindByBranch.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('nope')).rejects.toThrow('process.exit');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('wt list');
+        expect(stderrOutput).toContain('wt cd');
+    });
+
+    // --- Path resolution ---
+
+    it('should resolve by path when argument is an existing directory worktree', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // First stat: path exists and is a directory
+        mockStat.mockResolvedValueOnce({ isDirectory: () => true } as any);
+        mockFindByPath.mockResolvedValueOnce(mockWorktrees[1]);
+        // Second stat: target path verification
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('/fake/worktrees/feature-login');
+
+        expect(mockExeca).toHaveBeenCalledWith('/bin/zsh', [], {
+            cwd: '/fake/worktrees/feature-login',
+            stdio: 'inherit',
+            reject: false,
+        });
+    });
+
+    it('should fail when path exists but is not a directory', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // stat returns a file, not a directory
+        mockStat.mockResolvedValueOnce({ isDirectory: () => false } as any);
+
+        await expect(cdWorktreeHandler('/tmp/somefile.txt')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('is not a directory');
+    });
+
+    it('should fail when path is a directory but not a git worktree', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // First stat: path exists, is directory
+        mockStat.mockResolvedValueOnce({ isDirectory: () => true } as any);
+        // findWorktreeByPath returns null
+        mockFindByPath.mockResolvedValueOnce(null);
+        // stat for .git inside directory: throws (no .git)
+        mockStat.mockRejectedValueOnce(enoentError());
+
+        await expect(cdWorktreeHandler('/tmp/plain-dir')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('not a git worktree');
+    });
+
+    it('should fall through to branch lookup when path does not exist', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // stat throws → not a path, fall through to branch lookup
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        // stat for target path verification
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('main');
+
+        expect(mockExeca).toHaveBeenCalledWith('/bin/zsh', [], {
+            cwd: '/fake/repo',
+            stdio: 'inherit',
+            reject: false,
+        });
+    });
+
+    // --- Target path deleted from disk ---
+
+    it('should fail when resolved worktree path no longer exists on disk', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        // stat for input: throws (not a path)
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[1]);
+        // stat for target path verification: throws (deleted)
+        mockStat.mockRejectedValueOnce(enoentError());
+
+        await expect(cdWorktreeHandler('feature/login')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('no longer exists');
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    // --- Interactive selection (no argument) ---
+
+    it('should use interactive picker when no argument is given', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockSelectWorktree.mockResolvedValueOnce(mockWorktrees[1]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('');
+
+        expect(mockSelectWorktree).toHaveBeenCalledWith({
+            message: 'Select a worktree to cd into',
+            excludeMain: false,
+        });
+        expect(mockExeca).toHaveBeenCalledWith('/bin/zsh', [], {
+            cwd: '/fake/worktrees/feature-login',
+            stdio: 'inherit',
+            reject: false,
+        });
+    });
+
+    it('should exit 0 when user cancels interactive selection', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockSelectWorktree.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(0);
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('should exit 0 when interactive selection returns array', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockSelectWorktree.mockResolvedValueOnce([mockWorktrees[0], mockWorktrees[1]]);
+
+        await expect(cdWorktreeHandler('')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(0);
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('should write cancellation message to stderr not stdout', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockSelectWorktree.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('')).rejects.toThrow('process.exit');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('No worktree selected');
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    // --- Not in a git repo ---
+
+    it('should fail when not inside a git repository', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockExeca.mockResolvedValueOnce({ stdout: '', exitCode: 128 } as any);
+
+        await expect(cdWorktreeHandler('main')).rejects.toThrow('process.exit');
+
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('should write git error to stderr when not in a repo', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockExeca.mockResolvedValueOnce({ stdout: '', exitCode: 128 } as any);
+
+        await expect(cdWorktreeHandler('main')).rejects.toThrow('process.exit');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Not inside a git work tree');
+    });
+
+    // --- Subshell uses correct shell ---
+
+    it('should write entering message to stderr', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('main');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Entering');
+        expect(stderrOutput).toContain('/fake/repo');
+    });
+
+    it('should not write path to stdout', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('main');
+
+        expect(stdoutSpy).not.toHaveBeenCalled();
+    });
+
+    it('should propagate non-zero shell exit code', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        mockStat.mockResolvedValueOnce({} as any);
+        // Subshell exits with code 130
+        mockExeca
+            .mockResolvedValueOnce({ stdout: 'true', exitCode: 0 } as any) // git rev-parse
+            .mockResolvedValueOnce({ exitCode: 130 } as any); // shell
+
+        await expect(cdWorktreeHandler('main')).rejects.toThrow('process.exit');
+        expect(exitSpy).toHaveBeenCalledWith(130);
+    });
+
+    it('should exit 128 when shell is killed by signal', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        mockStat.mockResolvedValueOnce({} as any);
+        mockExeca
+            .mockResolvedValueOnce({ stdout: 'true', exitCode: 0 } as any) // git rev-parse
+            .mockResolvedValueOnce({ exitCode: undefined, signal: 'SIGKILL' } as any); // shell killed
+
+        await expect(cdWorktreeHandler('main')).rejects.toThrow('process.exit');
+        // SIGKILL = 9, so exit code should be 128 + 9 = 137
+        expect(exitSpy).toHaveBeenCalledWith(137);
+    });
+
+    // --- --print mode ---
+
+    it('should write only the path to stdout with --print', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[1]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('feature/login', { print: true });
+
+        expect(stdoutSpy).toHaveBeenCalledWith('/fake/worktrees/feature-login\n');
+        // Should only have the git rev-parse call, no subshell spawn
+        expect(mockExeca).toHaveBeenCalledTimes(1);
+        expect(mockExeca).toHaveBeenCalledWith('git', ['rev-parse', '--is-inside-work-tree'], { reject: false });
+    });
+
+    it('should not write entering message with --print', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockStat.mockRejectedValueOnce(enoentError());
+        mockFindByBranch.mockResolvedValueOnce(mockWorktrees[0]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('main', { print: true });
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).not.toContain('Entering');
+    });
+
+    it('should still exit 1 on error with --print', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockFindByBranch.mockResolvedValueOnce(null);
+
+        await expect(cdWorktreeHandler('missing', { print: true })).rejects.toThrow('process.exit');
+        expect(exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    // --- Detached worktree ---
+
+    it('should handle detached worktrees from interactive selection', async () => {
+        const { cdWorktreeHandler } = await import('../src/commands/cd.js');
+
+        mockSelectWorktree.mockResolvedValueOnce(mockWorktrees[2]);
+        mockStat.mockResolvedValueOnce({} as any);
+
+        await cdWorktreeHandler('');
+
+        expect(mockExeca).toHaveBeenCalledWith('/bin/zsh', [], {
+            cwd: '/fake/worktrees/detached-wt',
+            stdio: 'inherit',
+            reject: false,
+        });
+    });
+});

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mockReadFileSync = vi.fn(() => { throw new Error('ENOENT'); });
+vi.mock('node:fs', () => ({ readFileSync: mockReadFileSync }));
+
+describe('initHandler', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit');
+        }) as any);
+        mockReadFileSync.mockReset().mockImplementation(() => { throw new Error('ENOENT'); });
+    });
+
+    afterEach(() => {
+        stdoutSpy.mockRestore();
+        stderrSpy.mockRestore();
+        exitSpy.mockRestore();
+    });
+
+    it('should output bash/zsh shell function to stdout', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('wt()');
+        expect(output).toContain('command wt cd --print');
+        expect(output).toContain('builtin cd');
+    });
+
+    it('should output bash function for bash shell', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('bash');
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('wt()');
+    });
+
+    it('should output fish function for fish shell', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('fish');
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('function wt');
+        expect(output).toContain('$argv');
+    });
+
+    it('should write usage hint to stderr for zsh', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('eval');
+        expect(stderrOutput).toContain('.zshrc');
+    });
+
+    it('should write config.fish hint for fish shell', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('fish');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('config.fish');
+        expect(stderrOutput).not.toContain('.fishrc');
+    });
+
+    it('should include copyable append command in stderr', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain("echo 'eval \"$(wt init zsh)\"' >> ~/.zshrc");
+    });
+
+    it('should include fish append command for fish shell', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('fish');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain("echo 'wt init fish | source' >> ~/.config/fish/config.fish");
+    });
+
+    it('should exit 1 for unsupported shell', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+
+        expect(() => initHandler('powershell')).toThrow('process.exit');
+        expect(exitSpy).toHaveBeenCalledWith(1);
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Unsupported shell');
+    });
+
+    it('should be case-insensitive for shell name', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('ZSH');
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('wt()');
+    });
+
+    it('should not contain 2>/dev/null in shell functions', async () => {
+        const { getShellFunction } = await import('../src/commands/init.js');
+        expect(getShellFunction('zsh')).not.toContain('2>/dev/null');
+        expect(getShellFunction('fish')).not.toContain('2>/dev/null');
+    });
+
+    it('should include reload command in stderr', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('source ~/.zshrc');
+    });
+
+    it('should include fish reload command for fish', async () => {
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('fish');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('source ~/.config/fish/config.fish');
+    });
+
+    it('should show "already installed" when init line exists in rc file', async () => {
+        mockReadFileSync.mockReturnValueOnce('some stuff\neval "$(wt init zsh)"\nmore stuff');
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Already installed');
+        expect(stderrOutput).toContain('.zshrc');
+        // Should not show append/reload commands
+        expect(stderrOutput).not.toContain("echo '");
+        expect(stderrOutput).not.toContain('source');
+    });
+
+    it('should still output shell function even when already installed', async () => {
+        mockReadFileSync.mockReturnValueOnce('eval "$(wt init zsh)"');
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler('zsh');
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('wt()');
+    });
+});
+
+describe('detectShell', () => {
+    const originalShell = process.env.SHELL;
+
+    afterEach(() => {
+        process.env.SHELL = originalShell;
+    });
+
+    it('should detect zsh from $SHELL', async () => {
+        process.env.SHELL = '/bin/zsh';
+        const { detectShell } = await import('../src/commands/init.js');
+        expect(detectShell()).toBe('zsh');
+    });
+
+    it('should detect bash from $SHELL', async () => {
+        process.env.SHELL = '/usr/bin/bash';
+        const { detectShell } = await import('../src/commands/init.js');
+        expect(detectShell()).toBe('bash');
+    });
+
+    it('should detect fish from $SHELL', async () => {
+        process.env.SHELL = '/usr/local/bin/fish';
+        const { detectShell } = await import('../src/commands/init.js');
+        expect(detectShell()).toBe('fish');
+    });
+
+    it('should return null for unsupported $SHELL', async () => {
+        process.env.SHELL = '/bin/tcsh';
+        const { detectShell } = await import('../src/commands/init.js');
+        expect(detectShell()).toBeNull();
+    });
+
+    it('should return null when $SHELL is unset', async () => {
+        delete process.env.SHELL;
+        const { detectShell } = await import('../src/commands/init.js');
+        expect(detectShell()).toBeNull();
+    });
+});
+
+describe('initHandler auto-detection', () => {
+    let stdoutSpy: ReturnType<typeof vi.spyOn>;
+    let stderrSpy: ReturnType<typeof vi.spyOn>;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+    const originalShell = process.env.SHELL;
+
+    beforeEach(() => {
+        stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+        stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+        exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+            throw new Error('process.exit');
+        }) as any);
+    });
+
+    afterEach(() => {
+        stdoutSpy.mockRestore();
+        stderrSpy.mockRestore();
+        exitSpy.mockRestore();
+        process.env.SHELL = originalShell;
+    });
+
+    it('should auto-detect shell when no argument given', async () => {
+        process.env.SHELL = '/bin/zsh';
+        const { initHandler } = await import('../src/commands/init.js');
+        initHandler();
+
+        const output = stdoutSpy.mock.calls.map(c => c[0]).join('');
+        expect(output).toContain('wt()');
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Detected shell: zsh');
+    });
+
+    it('should exit 1 when no argument and $SHELL is unsupported', async () => {
+        process.env.SHELL = '/bin/tcsh';
+        const { initHandler } = await import('../src/commands/init.js');
+
+        expect(() => initHandler()).toThrow('process.exit');
+        expect(exitSpy).toHaveBeenCalledWith(1);
+        const stderrOutput = stderrSpy.mock.calls.map(c => c[0]).join('');
+        expect(stderrOutput).toContain('Could not detect shell');
+    });
+});
+
+describe('getShellFunction', () => {
+    it('should return same function for bash and zsh', async () => {
+        const { getShellFunction } = await import('../src/commands/init.js');
+        expect(getShellFunction('bash')).toBe(getShellFunction('zsh'));
+    });
+
+    it('should return different function for fish', async () => {
+        const { getShellFunction } = await import('../src/commands/init.js');
+        expect(getShellFunction('fish')).not.toBe(getShellFunction('zsh'));
+    });
+});


### PR DESCRIPTION
## Summary

Adds two new commands that work together to let users navigate into worktree directories with a native `cd` — no subshell required.

### `wt cd [pathOrBranch]`

Navigate into a worktree directory. Resolves by branch name, filesystem path, or interactive picker.

- **Default:** spawns a subshell in the target directory (works without any setup)
- **`--print`:** outputs the resolved path to stdout and exits — used by the shell wrapper below

Errors go to stderr, stdout is reserved for machine-readable output. Propagates shell exit codes and signals correctly.

### `wt init [shell]`

Outputs a shell wrapper function (zsh, bash, or fish) that intercepts `wt cd` and performs a native `builtin cd` using `--print`.

```bash
# Auto-detects shell from $SHELL
eval "$(wt init)"

# Or specify explicitly
eval "$(wt init zsh)"
```

- Auto-detects shell from `$SHELL` when no argument given
- Detects if already installed in the user's rc file
- Shows a copyable command to append the init line and reload the shell
- If `--print` fails, falls back to the normal subshell `wt cd`

### Other improvements

- `wt open` now routes all errors to `process.stderr.write` consistently
- Narrowed catch blocks to ENOENT where appropriate (cd.ts, open.ts)
- Added `reject: false` to `git rev-parse` calls for graceful error handling
- `wt open` outputs raw path when editor is `none`

### Files changed

| File | What |
|---|---|
| `src/commands/cd.ts` | New cd command handler |
| `src/commands/init.ts` | New init command with shell functions |
| `src/index.ts` | Register cd and init commands |
| `src/utils/tui.ts` | Add stdout stream option to selectWorktree |
| `src/commands/open.ts` | Consistent stderr, narrowed catches |
| `test/cd.test.ts` | 23 tests for cd |
| `test/init.test.ts` | 23 tests for init |
| `README.md` | Document shell integration |

Somewhere a GPU is overheating so I don't have to think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wt cd [pathOrBranch] (with --print) to print or open a worktree, wt init [shell] to emit shell integration for zsh/bash/fish, and CLI wiring for both.
  * TUI/select now supports forwarding stdout for scripted integration.

* **Bug Fixes**
  * Clearer stderr messaging, consistent exit codes, ENOENT-aware resolution, interactive-cancel handling, and editor-skip reliably prints path to stdout.

* **Documentation**
  * README updated with examples for open, cd, init, shell setup, and interactive usage.

* **Tests**
  * Added comprehensive tests for cd and init.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->