### PR TITLE
feat: Add cd command to navigate to worktree directories

### DIFF
--- a/build/commands/cd.js
+++ b/build/commands/cd.js
@@ -1,0 +1,110 @@
+import { execa } from "execa";
+import chalk from "chalk";
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { findWorktreeByBranch, findWorktreeByPath } from "../utils/git.js";
+import { selectWorktree } from "../utils/tui.js";
+export async function cdWorktreeHandler(pathOrBranch = "") {
+    try {
+        await execa("git", ["rev-parse", "--is-inside-work-tree"]);
+        let targetWorktree = null;
+        if (!pathOrBranch) {
+            const selected = await selectWorktree({
+                message: "Select a worktree to navigate to",
+                excludeMain: false,
+            });
+            if (!selected || Array.isArray(selected)) {
+                console.error(chalk.yellow("No worktree selected."));
+                process.exit(0);
+            }
+            targetWorktree = selected;
+        }
+        else {
+            // Try to find by path first
+            try {
+                const stats = await stat(pathOrBranch);
+                if (stats.isDirectory()) {
+                    targetWorktree = await findWorktreeByPath(pathOrBranch);
+                    if (!targetWorktree) {
+                        try {
+                            await stat(resolve(pathOrBranch, ".git"));
+                            targetWorktree = {
+                                path: resolve(pathOrBranch),
+                                head: '',
+                                branch: null,
+                                detached: false,
+                                locked: false,
+                                prunable: false,
+                                isMain: false,
+                                bare: false,
+                            };
+                        }
+                        catch {
+                            console.error(chalk.red(`The path "${pathOrBranch}" exists but is not a git worktree.`));
+                            process.exit(1);
+                        }
+                    }
+                }
+            }
+            catch {
+                // Not a valid path, try as branch name
+            }
+            if (!targetWorktree) {
+                targetWorktree = await findWorktreeByBranch(pathOrBranch);
+                if (!targetWorktree) {
+                    console.error(chalk.red(`Could not find a worktree for branch "${pathOrBranch}".`));
+                    console.error(chalk.yellow("Use 'wt list' to see existing worktrees, or run 'wt cd' without arguments to select interactively."));
+                    process.exit(1);
+                }
+            }
+        }
+        const targetPath = targetWorktree.path;
+        // Verify the target path exists
+        try {
+            await stat(targetPath);
+        }
+        catch {
+            console.error(chalk.red(`The worktree path "${targetPath}" no longer exists.`));
+            console.error(chalk.yellow("The worktree may have been removed. Run 'git worktree prune' to clean up."));
+            process.exit(1);
+        }
+        // Shell-escape the path by wrapping in single quotes
+        const escapedPath = "'" + targetPath.replace(/'/g, "'\\''") + "'";
+        const cdCommand = `cd ${escapedPath}`;
+        // Copy cd command to clipboard (cross-platform)
+        let clipboardCmd;
+        let clipboardArgs;
+        if (process.platform === "darwin") {
+            clipboardCmd = "pbcopy";
+            clipboardArgs = [];
+        }
+        else if (process.platform === "win32") {
+            clipboardCmd = "clip.exe";
+            clipboardArgs = [];
+        }
+        else {
+            clipboardCmd = "xclip";
+            clipboardArgs = ["-selection", "clipboard"];
+        }
+        try {
+            await execa(clipboardCmd, clipboardArgs, { input: cdCommand });
+            console.log(chalk.green(`Copied to clipboard: ${cdCommand}`));
+            const pasteHint = process.platform === "darwin" ? "Cmd+V" : "Ctrl+V";
+            console.log(chalk.gray(`Paste with ${pasteHint} and press Enter to navigate.`));
+        }
+        catch {
+            // Fallback if clipboard command is unavailable
+            console.error(chalk.yellow("Clipboard unavailable. Copy and run the command below:"));
+            process.stdout.write(cdCommand + "\n");
+        }
+    }
+    catch (error) {
+        if (error instanceof Error) {
+            console.error(chalk.red("Failed to resolve worktree:"), error.message);
+        }
+        else {
+            console.error(chalk.red("Failed to resolve worktree:"), error);
+        }
+        process.exit(1);
+    }
+}

--- a/build/index.js
+++ b/build/index.js
@@ -10,6 +10,7 @@ import { configHandler } from "./commands/config.js";
 import { prWorktreeHandler } from "./commands/pr.js";
 import { openWorktreeHandler } from "./commands/open.js";
 import { extractWorktreeHandler } from "./commands/extract.js";
+import { cdWorktreeHandler } from "./commands/cd.js";
 const program = new Command();
 program
     .name("wt")
@@ -83,6 +84,11 @@ program
     .option("-e, --editor <editor>", "Editor to use for opening the worktree (overrides default editor)")
     .description("Extract an existing branch as a new worktree. If no branch is specified, extracts the current branch.")
     .action(extractWorktreeHandler);
+program
+    .command("cd")
+    .argument("[pathOrBranch]", "Path to worktree or branch name")
+    .description("Print the path of a worktree for use with cd. Usage: cd $(wt cd)")
+    .action(cdWorktreeHandler);
 program
     .command("config")
     .description("Manage CLI configuration settings.")

--- a/src/commands/cd.ts
+++ b/src/commands/cd.ts
@@ -1,0 +1,112 @@
+import { execa } from "execa";
+import chalk from "chalk";
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import { findWorktreeByBranch, findWorktreeByPath, WorktreeInfo } from "../utils/git.js";
+import { selectWorktree } from "../utils/tui.js";
+
+export async function cdWorktreeHandler(pathOrBranch: string = "") {
+    try {
+        await execa("git", ["rev-parse", "--is-inside-work-tree"]);
+
+        let targetWorktree: WorktreeInfo | null = null;
+
+        if (!pathOrBranch) {
+            const selected = await selectWorktree({
+                message: "Select a worktree to navigate to",
+                excludeMain: false,
+            });
+
+            if (!selected || Array.isArray(selected)) {
+                console.error(chalk.yellow("No worktree selected."));
+                process.exit(0);
+            }
+
+            targetWorktree = selected;
+        } else {
+            // Try to find by path first
+            try {
+                const stats = await stat(pathOrBranch);
+                if (stats.isDirectory()) {
+                    targetWorktree = await findWorktreeByPath(pathOrBranch);
+                    if (!targetWorktree) {
+                        try {
+                            await stat(resolve(pathOrBranch, ".git"));
+                            targetWorktree = {
+                                path: resolve(pathOrBranch),
+                                head: '',
+                                branch: null,
+                                detached: false,
+                                locked: false,
+                                prunable: false,
+                                isMain: false,
+                                bare: false,
+                            };
+                        } catch {
+                            console.error(chalk.red(`The path "${pathOrBranch}" exists but is not a git worktree.`));
+                            process.exit(1);
+                        }
+                    }
+                }
+            } catch {
+                // Not a valid path, try as branch name
+            }
+
+            if (!targetWorktree) {
+                targetWorktree = await findWorktreeByBranch(pathOrBranch);
+                if (!targetWorktree) {
+                    console.error(chalk.red(`Could not find a worktree for branch "${pathOrBranch}".`));
+                    console.error(chalk.yellow("Use 'wt list' to see existing worktrees, or run 'wt cd' without arguments to select interactively."));
+                    process.exit(1);
+                }
+            }
+        }
+
+        const targetPath = targetWorktree.path;
+
+        // Verify the target path exists
+        try {
+            await stat(targetPath);
+        } catch {
+            console.error(chalk.red(`The worktree path "${targetPath}" no longer exists.`));
+            console.error(chalk.yellow("The worktree may have been removed. Run 'git worktree prune' to clean up."));
+            process.exit(1);
+        }
+
+        // Shell-escape the path by wrapping in single quotes
+        const escapedPath = "'" + targetPath.replace(/'/g, "'\\''") + "'";
+        const cdCommand = `cd ${escapedPath}`;
+
+        // Copy cd command to clipboard (cross-platform)
+        let clipboardCmd: string;
+        let clipboardArgs: string[];
+        if (process.platform === "darwin") {
+            clipboardCmd = "pbcopy";
+            clipboardArgs = [];
+        } else if (process.platform === "win32") {
+            clipboardCmd = "clip.exe";
+            clipboardArgs = [];
+        } else {
+            clipboardCmd = "xclip";
+            clipboardArgs = ["-selection", "clipboard"];
+        }
+
+        try {
+            await execa(clipboardCmd, clipboardArgs, { input: cdCommand });
+            console.log(chalk.green(`Copied to clipboard: ${cdCommand}`));
+            const pasteHint = process.platform === "darwin" ? "Cmd+V" : "Ctrl+V";
+            console.log(chalk.gray(`Paste with ${pasteHint} and press Enter to navigate.`));
+        } catch {
+            // Fallback if clipboard command is unavailable
+            console.error(chalk.yellow("Clipboard unavailable. Copy and run the command below:"));
+            process.stdout.write(cdCommand + "\n");
+        }
+    } catch (error) {
+        if (error instanceof Error) {
+            console.error(chalk.red("Failed to resolve worktree:"), error.message);
+        } else {
+            console.error(chalk.red("Failed to resolve worktree:"), error);
+        }
+        process.exit(1);
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { configHandler } from "./commands/config.js";
 import { prWorktreeHandler } from "./commands/pr.js";
 import { openWorktreeHandler } from "./commands/open.js";
 import { extractWorktreeHandler } from "./commands/extract.js";
+import { cdWorktreeHandler } from "./commands/cd.js";
 
 const program = new Command();
 
@@ -165,6 +166,12 @@ program
     "Extract an existing branch as a new worktree. If no branch is specified, extracts the current branch."
   )
   .action(extractWorktreeHandler);
+
+program
+  .command("cd")
+  .argument("[pathOrBranch]", "Path to worktree or branch name")
+  .description("Print the path of a worktree for use with cd. Usage: cd $(wt cd)")
+  .action(cdWorktreeHandler);
 
 program
   .command("config")


### PR DESCRIPTION
## Summary
- Adds a new `wt cd` command that lets users quickly navigate to a worktree directory
- Supports interactive worktree selection (fuzzy search) or direct lookup by branch name/path
- Copies `cd /path/to/worktree` to clipboard so users can paste (Cmd+V) and Enter to navigate

## Usage
```bash
wt cd              # Interactive: select from worktree list
wt cd feature-auth # Direct: by branch name
# Then Cmd+V + Enter to navigate
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new "cd" CLI command to locate and navigate to a git worktree. Supports interactive selection or supplying a path/branch, validates the target exists, and provides clear error or cancellation messages. Produces a shell-ready cd command, attempts to copy it to the clipboard with sensible fallbacks, and displays usage/paste hints for convenience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->